### PR TITLE
[test] Task Submission and Additional Tests

### DIFF
--- a/test/integration/allocation/idle_allocation_cost_validation_test.go
+++ b/test/integration/allocation/idle_allocation_cost_validation_test.go
@@ -8,21 +8,9 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
 )
-
-type AllocationResponse struct {
-	Code   int                    `json:"code"`
-	Status string                 `json:"status"`
-	Data   []map[string]CostEntry `json:"data"`
-}
-
-type CostEntry struct {
-	Name      string  `json:"name"`
-	CPUCost   float64 `json:"cpuCost"`
-	RAMCost   float64 `json:"ramCost"`
-	GPUCost   float64 `json:gpuCost`
-	TotalCost float64 `json:TotalCost`
-}
 
 func validateNonNegativeIdleCosts(t *testing.T, aggregate string, window string) {
 
@@ -54,7 +42,7 @@ func validateNonNegativeIdleCosts(t *testing.T, aggregate string, window string)
 		t.Fatalf("No allocation data returned for window %s", window)
 	}
 
-	var parsed AllocationResponse
+	var parsed api.AllocationResponse
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		t.Fatalf("failed to parse JSON: %s", err)
 	}
@@ -88,14 +76,15 @@ func validateNonNegativeIdleCosts(t *testing.T, aggregate string, window string)
 	}
 }
 
-func TestIdleResourceCostValidation(t *testing.T) {
+func TestIdleCostValidation(t *testing.T) {
 
 	windows := []string{"10m", "1h", "12h", "1d", "2d", "7d", "30d"}
-	aggregates := []string{"namespace", "cluster"}
+	aggregates := []string{"namespace", "cluster", "service", "pod", "node"}
 
 	for _, window := range windows {
 		for _, aggregate := range aggregates {
-			t.Run(window, func(t *testing.T) {
+			name := "Window: " + window + " Aggregate: " + aggregate
+			t.Run(name, func(t *testing.T) {
 				validateNonNegativeIdleCosts(t, aggregate, window)
 			})
 		}

--- a/test/integration/allocation/idle_allocation_cost_validation_test.go
+++ b/test/integration/allocation/idle_allocation_cost_validation_test.go
@@ -1,0 +1,73 @@
+package allocation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+)
+
+func validateNonNegativeIdleCosts(t *testing.T, aggregate string, window string) {
+
+	client := api.NewAPI()
+	req := api.AllocationRequest{
+		Window:     window,
+		Aggregate:  aggregate,
+		Idle:       "true",
+		Accumulate: "false",
+	}
+
+	resp, err := client.GetAllocation(req)
+	if err != nil {
+		t.Fatalf("Failed to query OpenCost allocation API with window %s: %v", window, err)
+	}
+	if resp.Code != 200 {
+		t.Fatalf("OpenCost allocation API returned error for window %s: code=%d", window, resp.Code)
+	}
+	if len(resp.Data) == 0 {
+		t.Fatalf("No allocation data returned for window %s", window)
+	}
+
+	foundIdle := false
+	fmt.Println(resp.Data)
+
+	for _, allocations := range resp.Data {
+		if idle, exists := allocations["__idle__"]; exists {
+			foundIdle = true
+
+			// instead for putting which values to check inside code, seeing them in one place might be better
+			costChecks := []struct {
+				name  string
+				value float64
+			}{
+				{"total cost", idle.TotalCost},
+				{"CPU cost", idle.CPUCost},
+				{"RAM cost", idle.RAMCost},
+				{"GPU cost", idle.GPUCost},
+			}
+
+			for _, check := range costChecks {
+				if check.value < 0 {
+					t.Errorf("Found negative %s in idle allocation: %f", check.name, check.value)
+				}
+			}
+		}
+	}
+	if !foundIdle {
+		t.Skipf("Idle Allocation not found for window %s, Verification skipped", window)
+	}
+}
+
+func TestIdleResourceCostValidation(t *testing.T) {
+
+	windows := []string{"10m", "1h", "12h", "1d", "2d", "7d", "30d"}
+	aggregates := []string{"namespace", "cluster"}
+
+	for _, window := range windows {
+		for _, aggregate := range aggregates {
+			t.Run(window, func(t *testing.T) {
+				validateNonNegativeIdleCosts(t, aggregate, window)
+			})
+		}
+	}
+}

--- a/test/integration/allocation/idle_allocation_cost_validation_test.go
+++ b/test/integration/allocation/idle_allocation_cost_validation_test.go
@@ -57,6 +57,7 @@ func validateNonNegativeIdleCosts(t *testing.T, aggregate string, window string)
 				name  string
 				value float64
 			}{
+				// list the cost values to be checked here
 				{"total cost", idle.TotalCost},
 				{"CPU cost", idle.CPUCost},
 				{"RAM cost", idle.RAMCost},

--- a/test/integration/allocation/non-negative_cost_validation_test.go
+++ b/test/integration/allocation/non-negative_cost_validation_test.go
@@ -1,0 +1,65 @@
+package allocation
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+)
+
+func validateNonNegativeCosts(t *testing.T, aggregate string, window string) {
+
+	client := api.NewAPI()
+	req := api.AllocationRequest{
+		Window:    window,
+		Aggregate: aggregate,
+	}
+
+	resp, err := client.GetAllocation(req)
+	if err != nil {
+		t.Fatalf("Failed to query OpenCost allocation API with window %s: %v", window, err)
+	}
+	if resp.Code != 200 {
+		t.Fatalf("OpenCost allocation API returned error for window %s: code=%d", window, resp.Code)
+	}
+	if len(resp.Data) == 0 {
+		t.Fatalf("No allocation data returned for window %s", window)
+	}
+	//fmt.Println(resp.Data)
+
+	for _, allocations := range resp.Data {
+		for _, entry := range allocations {
+
+			costChecks := []struct {
+				name  string
+				value float64
+			}{
+				// Cost values we are checking if they are negative or not
+				{"total cost", entry.TotalCost},
+				{"CPU cost", entry.CPUCost},
+				{"RAM cost", entry.RAMCost},
+				{"GPU cost", entry.GPUCost},
+			}
+
+			for _, check := range costChecks {
+				if check.value < 0 {
+					t.Errorf("Found negative %s in %s allocation: %f", check.name, entry.Name, check.value)
+				}
+			}
+		}
+	}
+}
+
+func TestNonNegativeCostValidation(t *testing.T) {
+
+	windows := []string{"10m", "1h", "12h", "1d", "2d", "7d", "30d"}
+	aggregates := []string{"namespace", "cluster", "service", "pod", "node"}
+
+	for _, window := range windows {
+		for _, aggregate := range aggregates {
+			name := "Window: " + window + " Aggregate: " + aggregate
+			t.Run(name, func(t *testing.T) {
+				validateNonNegativeCosts(t, aggregate, window)
+			})
+		}
+	}
+}

--- a/test/integration/allocation/test.bats
+++ b/test/integration/allocation/test.bats
@@ -10,6 +10,14 @@ teardown() {
     go test ./test/integration/allocation/allocation_controller_consistency_test.go
 }
 
-@test "allocation: Idle allocation Cost Validations" {
+@test "allocation: Idle allocation Cost Validation" {
     go test test/integration/allocation/idle_allocation_cost_validation_test.go
+}
+
+@test "allocation: Non negative Cost Validation" {
+    go test test/integration/allocation/non-negative_cost_validation_test.go
+}
+
+@test "allocation: TotalCost equal to sum of Costs" {
+    go test test/integration/allocation/total_cost_equal_sum_of_costs_test.go
 }

--- a/test/integration/allocation/test.bats
+++ b/test/integration/allocation/test.bats
@@ -9,3 +9,7 @@ teardown() {
 @test "allocation: controller kind consistency" {
     go test ./test/integration/allocation/allocation_controller_consistency_test.go
 }
+
+@test "allocation: Idle allocation Cost Validations" {
+    go test test/integration/allocation/idle_allocation_cost_validation_test.go
+}

--- a/test/integration/allocation/total_cost_equal_sum_of_costs_test.go
+++ b/test/integration/allocation/total_cost_equal_sum_of_costs_test.go
@@ -1,0 +1,60 @@
+package allocation
+
+import (
+	"math"
+	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+)
+
+func isTotalSumEqualTotalCost(entry api.AllocationResponseItem) bool {
+	sum := 0.0
+	sum += entry.CPUCost + entry.GPUCost + entry.RAMCost + entry.NetworkCost + entry.NetworkCrossZoneCost + entry.NetworkCrossRegionCost + entry.NetworkInternetCost + entry.LoadBalancerCost + entry.RAMCost + entry.SharedCost
+	for _, persistentVolume := range entry.PersistentVolumes {
+		sum += persistentVolume.Cost
+	}
+	return math.Round(sum) == math.Round(entry.TotalCost)
+}
+
+func validatesum(t *testing.T, aggregate string, window string) {
+
+	client := api.NewAPI()
+	req := api.AllocationRequest{
+		Window:    window,
+		Aggregate: aggregate,
+	}
+
+	resp, err := client.GetAllocation(req)
+	if err != nil {
+		t.Fatalf("Failed to query OpenCost allocation API with window %s: %v", window, err)
+	}
+	if resp.Code != 200 {
+		t.Fatalf("OpenCost allocation API returned error for window %s: code=%d", window, resp.Code)
+	}
+	if len(resp.Data) == 0 {
+		t.Fatalf("No allocation data returned for window %s", window)
+	}
+
+	for _, allocations := range resp.Data {
+		for _, entry := range allocations {
+			if isTotalSumEqualTotalCost(entry) == false {
+				t.Errorf("TotalCost and sum of costs not matching for entry %s", entry.Name)
+			}
+		}
+	}
+}
+
+func TestToalCostValidation(t *testing.T) {
+
+	windows := []string{"10m", "1h", "12h", "1d", "2d", "7d", "30d"}
+	aggregates := []string{"namespace", "cluster", "service", "pod", "node"}
+
+	for _, window := range windows {
+		for _, aggregate := range aggregates {
+			name := "Window: " + window + " Aggregate: " + aggregate
+			t.Run(name, func(t *testing.T) {
+				validatesum(t, aggregate, window)
+			})
+		}
+	}
+}


### PR DESCRIPTION
### Task
To check for negative costs in `__idle__ ` . Demo Page: https://demo.infra.opencost.io/?window=1d&agg=namespace.

### Solution Approach
On inspecting the demo page and going to the networks tab we find the following request made to[ this endpoint](https://demo.infra.opencost.io/model/allocation/compute?window=1d&aggregate=namespace&includeIdle=true&step=1d&accumulate=false).
![repo1](https://github.com/user-attachments/assets/0b68aea1-7ba7-4b2e-a6d2-0d2083918bce)
To receive the response with `__idle__` present, the `includeIdle=true` and  `accumulate=false` parameter values should be set.
Hence we need to create such a request in order to validate that negative cost values are not present in `__idle__`.
This can be done either by using the `github.com/opencost/opencost-integration-tests/pkg/api` library (done in the already present tests of the repository) or by simply using `net/http` and then parsing the json response. There is a problem with the first approach -- the `includeIdle` field is not present in `github.com/opencost/opencost-integration-tests/pkg/api`. I have created a PR(#7) solving this issue.

I had done the task using the first approach initially (present in a different branch [link](https://github.com/shinigami-777/opencost-integration-tests/blob/task-solution-1/test/integration/allocation/idle_allocation_cost_validation_test.go). We can see on running it, the test cases get skipped due to `__idle__` not found. Solution in the PR is using the second approach.

Once we find the `__idle__` entry , we then check if negative cost values are present. If a negative value is found, error is thrown for that test case.

### File created

- `test/integration/allocation/idle_allocation_cost_validation_test.go`

### Test
The test cases having different window and aggregate values are generated inside [TestIdleResourceCostValidation](https://github.com/shinigami-777/opencost-integration-tests/blob/solution-2/test/integration/allocation/idle_allocation_cost_validation_test.go#L79) function. The [validateNonNegativeIdleCosts](https://github.com/shinigami-777/opencost-integration-tests/blob/solution-2/test/integration/allocation/idle_allocation_cost_validation_test.go#L15) function checks for each test case. This pattern is same as the ones in already present tests.

Inside validateNonNegativeIdleCosts:
- The http request is send and the json response is parsed.
- In the response.Data if the `__idle__` entry is present: cost values are checked to find negative values.
- If  `__idle__` not present, test case is Skipped.
- Test fails if negative values was found, else Passed.

The entries being checked can be listed [here](https://github.com/shinigami-777/opencost-integration-tests/blob/solution-2/test/integration/allocation/idle_allocation_cost_validation_test.go#L61). There are more entries like `NetworkCost`, `LoadBalacerCost`, etc than the ones we see on the demo page which can be added to the list and checked .

### Test Results
![repo5](https://github.com/user-attachments/assets/78dd9b0b-750c-4366-968d-6ff0e5eb4a7e)
**Test Status**: Failed (Bug is present)

### Additional Tests
The following tests are created -
1. **To check for negative cost values in all entries([non-negative_cost_validation_test.go](https://github.com/shinigami-777/opencost-integration-tests/blob/solution-2/test/integration/allocation/non-negative_cost_validation_test.go))** : 
We can check for all entries if the cost is negative or not using the same logic as in the `__idle__` case. If it is negative then error is thrown.

**Test Results**

![repo7](https://github.com/user-attachments/assets/41be8198-a527-4d35-87eb-d68d2c6f62c7)
**Test Status**: Passed (The `__idle__`  entires were not included here as the `github.com/opencost/opencost-integration-tests/pkg/api` library was used to make the requests with only the window and aggregate parameter set).

**Conclusion**: We can confirm that the negative cost bug is only present for `__idle__` entries.

2. **To check if total cost is equal to the sum of all costs present ([total_cost_equal_sum_of_costs_test.go](https://github.com/shinigami-777/opencost-integration-tests/blob/solution-2/test/integration/allocation/total_cost_equal_sum_of_costs_test.go)):** 
 The total sum of all the cost fields is calculated using [like this](https://github.com/shinigami-777/opencost-integration-tests/blob/solution-2/test/integration/allocation/total_cost_equal_sum_of_costs_test.go#L12). In the demo page there are only three cost values given but in reality more values like `NetworkCost`, `LoadBalacerCost`, present. The sum is calculated using all the cost values from the API endpoint. As there might be errors due to decimal values, we check if the rounded values for TotalCost is equal to the calculated sum or not . If they don't match then error is throw and test fails.

**Test Results**

![repo8](https://github.com/user-attachments/assets/d576107e-1b8d-4e7e-8bd4-7cea403ed683)

![repo9](https://github.com/user-attachments/assets/a9597319-3fda-46ff-a210-db0384104fe5)
**Test Status:** Failed


