### PR TITLE
Add negative idle test for allocation API

### DIFF
--- a/test/integration/allocation/negative_idle_test.go
+++ b/test/integration/allocation/negative_idle_test.go
@@ -1,0 +1,38 @@
+package allocation
+
+import (
+    "encoding/json"
+    "net/http"
+    "testing"
+)
+
+func TestNegativeIdle(t *testing.T) {
+    url := "https://demo.infra.opencost.io/model/allocation/compute?window=1d&aggregate=namespace&includeIdle=true&step=1d&accumulate=false"
+    resp, err := http.Get(url)
+    if err != nil {
+        t.Fatal("Failed to query API: ", err.Error()) // Avoid %v
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        t.Fatal("Unexpected status code: ", resp.StatusCode)
+    }
+
+    var response struct {
+        Data []map[string]interface{} `json:"data"` // Fixed tag
+    }
+    if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+        t.Fatal("Failed to parse JSON: ", err.Error()) // Avoid %v
+    }
+
+    for _, allocSet := range response.Data {
+        if idle, ok := allocSet["__idle__"].(map[string]interface{}); ok {
+            if cpuIdle, ok := idle["cpuCoreIdleHours"].(float64); ok && cpuIdle < 0 {
+                t.Errorf("Negative cpuCoreIdleHours in __idle__: %f", cpuIdle)
+            }
+            if ramIdle, ok := idle["ramByteIdleHours"].(float64); ok && ramIdle < 0 {
+                t.Errorf("Negative ramByteIdleHours in __idle__: %f", ramIdle)
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Description**:
This PR implements an integration test to detect negative idle values in the `/model/allocation/compute` endpoint, addressing the coding challenge for issue #3141 (LFX Mentorship application). The test queries the API, parses the response, and checks `cpuCoreIdleHours` and `ramByteIdleHours` in the `__idle__` entry, failing if any are negative.

**Test Details**:
- File: `test/integration/allocation/negative_idle_test.go`
- Endpoint: `https://demo.infra.opencost.io/model/allocation/compute?window=1d&aggregate=namespace&includeIdle=true&step=1d&accumulate=false`
- Checks: Negative values in `__idle__.cpuCoreIdleHours` and `__idle__.ramByteIdleHours`
- Dependencies: Standard Go libraries (`net/http`, `encoding/json`, `testing`)

**How to Run**:
```bash
go test ./test/integration/allocation -v -run TestNegativeIdle