### PR TITLE
test: skip pods not alive at query endTime in pod label/count tests

### DIFF
--- a/test/integration/api/allocation/pod_annotations_test.go
+++ b/test/integration/api/allocation/pod_annotations_test.go
@@ -82,6 +82,7 @@ func TestPodAnnotations(t *testing.T) {
 			type PodData struct {
 				Pod              string
 				Alive            bool
+				InAlloc          bool
 				promAnnotations  map[string]string
 				AllocAnnotations map[string]string
 			}
@@ -130,6 +131,7 @@ func TestPodAnnotations(t *testing.T) {
 					t.Logf("[Skipped] - No Annotations for Pod: %s", pod)
 					continue
 				}
+				podAnnotations.InAlloc = true
 				podAnnotations.AllocAnnotations = allocationResponseItem.Properties.Annotations
 			}
 
@@ -140,6 +142,17 @@ func TestPodAnnotations(t *testing.T) {
 				t.Logf("Pod: %s", pod)
 				if podAnnotations.Alive == false {
 					t.Logf("Skipping %s. Pod Dead", pod)
+					continue
+				}
+				// Skip pods that the Allocation API did not return. A
+				// pod can appear in kube_pod_annotations and briefly in
+				// kube_pod_container_status_running yet be absent from
+				// /allocation, which only reports pods with coincident
+				// usage metrics. Comparing annotations in that case is
+				// a window-boundary race, not an annotation-propagation
+				// bug.
+				if !podAnnotations.InAlloc {
+					t.Logf("Skipping %s. Pod not present in /allocation response.", pod)
 					continue
 				}
 				// Prometheus Result will have fewer Annotations.

--- a/test/integration/api/allocation/pod_labels_test.go
+++ b/test/integration/api/allocation/pod_labels_test.go
@@ -66,6 +66,32 @@ func TestPodLabels(t *testing.T) {
 				podRunningStatus[pod] = runningStatus
 			}
 
+			// Pod Info - narrow the "running" set to pods that were actually
+			// running at the query endTime using a 1m resolution subquery,
+			// matching the pattern used in pod_annotations_test.go.
+			// Pods that only briefly existed earlier in the 24h window may
+			// not appear in /allocation, and comparing their labels yields
+			// false negatives that have nothing to do with label
+			// propagation.
+			promPodInfoInput := prometheus.PrometheusInput{}
+			promPodInfoInput.Metric = "kube_pod_container_status_running"
+			promPodInfoInput.MetricNotEqualTo = "0"
+			promPodInfoInput.AggregateBy = []string{"container", "pod", "namespace", "node"}
+			promPodInfoInput.Function = []string{"avg"}
+			promPodInfoInput.AggregateWindow = tc.window
+			promPodInfoInput.AggregateResolution = podStatusResolution
+			promPodInfoInput.Time = &endTime
+
+			podInfo, err := client.RunPromQLQuery(promPodInfoInput, t)
+			if err != nil {
+				t.Fatalf("Error while calling Prometheus API %v", err)
+			}
+
+			alive := make(map[string]bool)
+			for _, r := range podInfo.Data.Result {
+				alive[r.Metric.Pod] = true
+			}
+
 			// -------------------------------
 			// Pod Labels
 			// avg_over_time(kube_pod_labels{%s}[%s])
@@ -84,6 +110,8 @@ func TestPodLabels(t *testing.T) {
 			// Store Results in a Pod Map
 			type PodData struct {
 				Pod         string
+				Alive       bool
+				InAlloc     bool
 				PromLabels  map[string]string
 				AllocLabels map[string]string
 			}
@@ -102,6 +130,7 @@ func TestPodLabels(t *testing.T) {
 
 				podMap[pod] = &PodData{
 					Pod:        pod,
+					Alive:      alive[pod],
 					PromLabels: labels,
 				}
 			}
@@ -128,12 +157,31 @@ func TestPodLabels(t *testing.T) {
 					t.Logf("Pod Information Missing from Prometheus %s", pod)
 					continue
 				}
+				podLabels.InAlloc = true
 				podLabels.AllocLabels = allocationResponseItem.Properties.Labels
 			}
 
 			// Compare Results
 			for pod, podLabels := range podMap {
 				t.Logf("Pod: %s", pod)
+
+				// Skip pods that were not alive at the query end. They
+				// may have been running earlier in the window but
+				// /allocation only reports pods with coincident usage
+				// metrics, so label comparisons would be noisy.
+				if !podLabels.Alive {
+					t.Logf("Skipping %s. Pod Dead at query end.", pod)
+					continue
+				}
+				// Skip pods that were not returned by /allocation. A pod
+				// can show up in kube_pod_labels but not in /allocation
+				// when it was very short lived or lacked CPU/memory
+				// usage samples, which is a window-boundary race rather
+				// than a label-propagation bug.
+				if !podLabels.InAlloc {
+					t.Logf("Skipping %s. Pod not present in /allocation response.", pod)
+					continue
+				}
 
 				// Prometheus Result will have fewer labels.
 				// Allocation has oracle and feature related labels

--- a/test/integration/query/count/allocation_running_pods_test.go
+++ b/test/integration/query/count/allocation_running_pods_test.go
@@ -74,6 +74,33 @@ func TestQueryAllocation(t *testing.T) {
 				t.Fatalf("Error while calling Prometheus API %v", err)
 			}
 
+			// Narrow the Prometheus pod set to pods alive at the query
+			// endTime using a 1m-resolution subquery. Without this,
+			// pods that were only very briefly running inside the 24h
+			// window show up in Prometheus (as their avg_over_time is
+			// non-zero) but are absent from /allocation, which only
+			// reports pods with coincident usage samples. That is a
+			// window-boundary race, not a pod-count bug.
+			promAliveInput := prometheus.PrometheusInput{
+				Metric:              "kube_pod_container_status_running",
+				MetricNotEqualTo:    "0",
+				Function:            []string{"avg"},
+				AggregateBy:         []string{"container", "pod", "namespace", "node"},
+				AggregateWindow:     tc.window,
+				AggregateResolution: "1m",
+				Time:                &endTime,
+			}
+
+			promAliveResponse, err := client.RunPromQLQuery(promAliveInput, t)
+			if err != nil {
+				t.Fatalf("Error while calling Prometheus API %v", err)
+			}
+
+			alivePods := make(map[string]bool)
+			for _, metric := range promAliveResponse.Data.Result {
+				alivePods[metric.Metric.Pod] = true
+			}
+
 			// Calculate Number of Pods per Aggregate for API Object
 			type podAggregation struct {
 				Pods []string
@@ -110,6 +137,14 @@ func TestQueryAllocation(t *testing.T) {
 				pod := metric.Metric.Pod
 				// This pod was down, unable to do it with the query
 				if metric.Value.Value == 0 {
+					continue
+				}
+				// Skip pods that are not alive at the query end time.
+				// /allocation only returns pods with usage data in the
+				// window, so short-lived pods that were up earlier in
+				// the 24h window but not at endTime would otherwise
+				// produce spurious mismatches.
+				if !alivePods[pod] {
 					continue
 				}
 				promAggregateItem, namespacePresent := promAggregateCount[podNamespace]

--- a/test/integration/query/count/allocation_running_pods_test.go
+++ b/test/integration/query/count/allocation_running_pods_test.go
@@ -96,9 +96,11 @@ func TestQueryAllocation(t *testing.T) {
 				t.Fatalf("Error while calling Prometheus API %v", err)
 			}
 
+			// Key by namespace/pod so that identically-named pods
+			// living in different namespaces are not conflated.
 			alivePods := make(map[string]bool)
 			for _, metric := range promAliveResponse.Data.Result {
-				alivePods[metric.Metric.Pod] = true
+				alivePods[metric.Metric.Namespace+"/"+metric.Metric.Pod] = true
 			}
 
 			// Calculate Number of Pods per Aggregate for API Object
@@ -144,7 +146,7 @@ func TestQueryAllocation(t *testing.T) {
 				// window, so short-lived pods that were up earlier in
 				// the 24h window but not at endTime would otherwise
 				// produce spurious mismatches.
-				if !alivePods[pod] {
+				if !alivePods[podNamespace+"/"+pod] {
 					continue
 				}
 				promAggregateItem, namespacePresent := promAggregateCount[podNamespace]

--- a/test/integration/query/count/allocations_summary_running_pods_test.go
+++ b/test/integration/query/count/allocations_summary_running_pods_test.go
@@ -74,6 +74,33 @@ func TestQueryAllocationSummary(t *testing.T) {
 				t.Fatalf("Error while calling Prometheus API %v", err)
 			}
 
+			// Narrow the Prometheus pod set to pods alive at the query
+			// endTime using a 1m-resolution subquery. Without this,
+			// pods that were only very briefly running inside the 24h
+			// window show up in Prometheus (as their avg_over_time is
+			// non-zero) but are absent from /allocation/summary, which
+			// only reports pods with coincident usage samples. That is
+			// a window-boundary race, not a pod-count bug.
+			promAliveInput := prometheus.PrometheusInput{
+				Metric:              "kube_pod_container_status_running",
+				MetricNotEqualTo:    "0",
+				Function:            []string{"avg"},
+				AggregateBy:         []string{"container", "pod", "namespace", "node"},
+				AggregateWindow:     tc.window,
+				AggregateResolution: "1m",
+				Time:                &endTime,
+			}
+
+			promAliveResponse, err := client.RunPromQLQuery(promAliveInput, t)
+			if err != nil {
+				t.Fatalf("Error while calling Prometheus API %v", err)
+			}
+
+			alivePods := make(map[string]bool)
+			for _, metric := range promAliveResponse.Data.Result {
+				alivePods[metric.Metric.Pod] = true
+			}
+
 			var apiAllocationPodNames []string
 			for podName, _ := range apiResponse.Data.Sets[0].Allocations {
 				// Synthetic value generated and returned by /allocation and not /prometheus
@@ -90,6 +117,14 @@ func TestQueryAllocationSummary(t *testing.T) {
 			for _, promItem := range promResponse.Data.Result {
 				// This pod was down, unable to do it with the query
 				if promItem.Value.Value == 0 {
+					continue
+				}
+				// Skip pods that are not alive at the query end time.
+				// /allocation/summary only returns pods with usage data
+				// in the window, so short-lived pods that were up
+				// earlier in the 24h window but not at endTime would
+				// otherwise produce spurious mismatches.
+				if !alivePods[promItem.Metric.Pod] {
 					continue
 				}
 				if !slices.Contains(promPodNames, promItem.Metric.Pod) {

--- a/test/integration/query/count/allocations_summary_running_pods_test.go
+++ b/test/integration/query/count/allocations_summary_running_pods_test.go
@@ -96,9 +96,11 @@ func TestQueryAllocationSummary(t *testing.T) {
 				t.Fatalf("Error while calling Prometheus API %v", err)
 			}
 
+			// Key by namespace/pod so that identically-named pods
+			// living in different namespaces are not conflated.
 			alivePods := make(map[string]bool)
 			for _, metric := range promAliveResponse.Data.Result {
-				alivePods[metric.Metric.Pod] = true
+				alivePods[metric.Metric.Namespace+"/"+metric.Metric.Pod] = true
 			}
 
 			var apiAllocationPodNames []string
@@ -124,7 +126,7 @@ func TestQueryAllocationSummary(t *testing.T) {
 				// in the window, so short-lived pods that were up
 				// earlier in the 24h window but not at endTime would
 				// otherwise produce spurious mismatches.
-				if !alivePods[promItem.Metric.Pod] {
+				if !alivePods[promItem.Metric.Namespace+"/"+promItem.Metric.Pod] {
 					continue
 				}
 				if !slices.Contains(promPodNames, promItem.Metric.Pod) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The `opencost/opencost` merge-queue runs keep failing on the same four flaky integration tests (e.g. runs [24686624556](https://github.com/opencost/opencost/actions/runs/24686624556) and [24689201144](https://github.com/opencost/opencost/actions/runs/24689201144)):

- `TestPodLabels/Today`
- `TestPodAnnotations/Today`, `TestPodAnnotations/Last_Two_Days`
- `TestQueryAllocation/Yesterday`
- `TestQueryAllocationSummary/Yesterday`

## Root cause

Investigation in [opencost/opencost#3753](https://github.com/opencost/opencost/pull/3753) traced every one of these failures to the same root cause. For a pod like `coredns-74d8fcf7c8-r8m5c`:

- The pod appears in Prometheus `kube_pod_container_status_running`, `kube_pod_labels`, and `kube_pod_annotations` with non-zero values over a 24h window.
- The pod is absent from OpenCost's `/allocation` (and `/allocation/summary`) response.
- OpenCost populates `/allocation` via `QueryPods` / `QueryPodsUID` in `modules/prometheus-source/pkg/prom/metricsquerier.go`:

  ```
  avg(kube_pod_container_status_running{} != 0) by (pod, ns, uid, ...)[24h:<N>m]
  ```

  where `<N> = DataResolutionMinutes` (default 5), so a pod that was only briefly running inside the window can miss every subquery sample and never enter `podMap` in `pkg/costmodel/allocation_helpers.go`.

The failing tests then compare labels / annotations / pod counts against an `/allocation` response that does not include that short-lived pod. This is a query-window race, not a label-propagation or counting bug.

## The fix

PR #68 ("check pod annotations for pods that are alive") introduced the pattern — a 1m-resolution subquery on `kube_pod_container_status_running` to confirm a pod was alive at `endTime` — but only applied it to `TestPodAnnotations`. The same filter was still missing from `TestPodLabels` and the two pod-count tests, and the annotations test also did not handle the case where a pod is alive at `endTime` yet still missing from `/allocation` (comparing against `nil` allocation metadata produces a false negative on every Prometheus annotation).

This PR:

1. Applies the PR #68 "alive at `endTime`" 1m-resolution subquery filter to `pod_labels_test.go` and to both pod-count tests (`allocation_running_pods_test.go`, `allocations_summary_running_pods_test.go`).
2. In both the label and annotation tests, also skips pods that `/allocation` did not return — there is no allocation map to compare to in that case, and the mismatch is a window-boundary race rather than a test failure.

The pod-count tests now additionally require each Prometheus pod to be alive at `endTime` (1m resolution), which matches the set of pods that `/allocation` is actually able to report.

## Response to Copilot review

The Cursor Cloud Agent that produced this PR does not have write access to post review comment replies on this repo, so the responses are recorded here.

### 1. `alivePods` keyed by pod name only — addressed in 4119b4c

> discussion [r3138082217](https://github.com/opencost/opencost-integration-tests/pull/69#discussion_r3138082217) on `allocation_running_pods_test.go`

Good catch. The `alivePods` map is now keyed by `namespace/pod` in both `TestQueryAllocation` and `TestQueryAllocationSummary` so identically-named pods in different namespaces are not conflated. `TestQueryAllocationSummary` had the same latent bug even though Copilot only flagged the allocation test — fixed in the same commit.

### 2. `[24h:1m]` subquery vs instant / `max_over_time` query — disagree, not making the change

> discussions [r3138082249](https://github.com/opencost/opencost-integration-tests/pull/69#discussion_r3138082249) (`allocation_running_pods_test.go`), [r3138082272](https://github.com/opencost/opencost-integration-tests/pull/69#discussion_r3138082272) (`allocations_summary_running_pods_test.go`), and [r3138082299](https://github.com/opencost/opencost-integration-tests/pull/69#discussion_r3138082299) (`pod_labels_test.go`)

Copilot suggested replacing the `[tc.window:1m]` subquery with either an instant query at `endTime` or a `max_over_time` over a short lookback to reduce Prometheus payload size. I'm not making this change here, for three reasons:

- **Consistency with #68.** The 1m-resolution subquery over `tc.window` is the exact pattern introduced in #68 for `TestPodAnnotations` and has already been validated against the Prometheus stack the merge queue exercises. The entire point of this PR is to apply that already-working pattern to the remaining three tests so they pass or fail on the same criterion. Switching three of the four callers to an instant / `max_over_time` query would re-introduce exactly the window-boundary semantic drift this PR is trying to close.
- **Cannot be validated from here.** The Cursor Cloud Agent has no access to a live OpenCost / Prometheus stack, so it cannot verify that an instant query at `endTime` (or `max_over_time` over 1h) returns the same pod set the `/allocation` handler sees. The 1m subquery matches OpenCost's internal resolution and is the known-good reference.
- **The efficiency concern is small in this context.** These tests run once per test case against a demo/CI Prometheus; the query is already narrowed by `kube_pod_container_status_running{} != 0` and aggregated by `(container, pod, namespace, node)`. A pure efficiency refactor of the alive query makes more sense as a follow-up PR that touches all four tests in lock-step (so `TestPodAnnotations` retains the same semantics as the other three), after a maintainer has confirmed the lighter query is equivalent against a live stack.

Happy to revisit in a follow-up if a maintainer would prefer the instant-query form across all four tests together.

## Related Issues

- Resolves the recurring flaky failures on `opencost/opencost` merge-queue runs (e.g. [run 24686624556](https://github.com/opencost/opencost/actions/runs/24686624556), [run 24689201144](https://github.com/opencost/opencost/actions/runs/24689201144)).
- Follows the pattern established by #68.
- Based on the investigation from [opencost/opencost#3753](https://github.com/opencost/opencost/pull/3753), which landed the proposed patch under `docs/integration-test-flake-fix/` in the `opencost` repo because it did not have write access here.

## Testing

- `go vet ./test/integration/api/allocation/... ./test/integration/query/count/...` — clean.
- `go test -run '^$' ./test/integration/api/allocation/... ./test/integration/query/count/...` — both packages compile and report `ok`.
- `gofmt -l` clean on the three touched files that were already LF-ended (`pod_labels_test.go`, `allocation_running_pods_test.go`, `allocations_summary_running_pods_test.go`). `pod_annotations_test.go` was already CRLF-ended on `main` prior to this change, so gofmt flags it on both `main` and this branch; no behavioural change.

Runtime validation requires a live OpenCost stack and the merge queue on `opencost/opencost`, which is only exercisable by a maintainer applying this to `main` here and re-running the queue.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5473473-a3a8-4acf-8e10-946a1164076b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5473473-a3a8-4acf-8e10-946a1164076b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

