### PR TITLE
Add smoke tests for allocation, allocation summary, and assets endpoints

### DIFF
--- a/test/integration/api/allocation/allocation_smoke_test.go
+++ b/test/integration/api/allocation/allocation_smoke_test.go
@@ -1,0 +1,49 @@
+package allocation
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+	"github.com/opencost/opencost-integration-tests/pkg/env"
+)
+
+func TestAllocationSmoke(t *testing.T) {
+	apiObj := api.NewAPI()
+
+	// logging incase we can trace potential env issues with go test -v
+	t.Logf("Smoke target (OPENCOST_URL or default): %s", env.GetDefaultURL())
+
+	testCases := []struct {
+		name   string
+		window string
+	}{
+		{
+			name:   "SimpleValidQuery_1d",
+			window: "1d",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			response, err := apiObj.GetAllocation(api.AllocationRequest{
+				Window: tc.window,
+			})
+
+			if err != nil {
+				t.Fatalf("Error while calling Allocation API %v", err)
+			}
+
+			if response.Code != 200 {
+				t.Errorf("/allocation returned non-200 code: %d", response.Code)
+			}
+
+			itemCount := 0
+			for _, step := range response.Data {
+				itemCount += len(step)
+			}
+			t.Logf("/allocation OK: code=%d, steps=%d, allocation items=%d",
+				response.Code, len(response.Data), itemCount)
+		})
+	}
+}

--- a/test/integration/api/allocation/allocation_smoke_test.go
+++ b/test/integration/api/allocation/allocation_smoke_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestAllocationSmoke(t *testing.T) {
-	apiObj := api.NewAPI()
+	apiClient := api.NewAPI()
 
-	// logging incase we can trace potential env issues with go test -v
+	// logging in case we can trace potential env issues with go test -v
 	t.Logf("Smoke target (OPENCOST_URL or default): %s", env.GetDefaultURL())
 
 	testCases := []struct {
@@ -26,7 +26,7 @@ func TestAllocationSmoke(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			response, err := apiObj.GetAllocation(api.AllocationRequest{
+			response, err := apiClient.GetAllocation(api.AllocationRequest{
 				Window: tc.window,
 			})
 

--- a/test/integration/api/allocation/allocation_smoke_test.go
+++ b/test/integration/api/allocation/allocation_smoke_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func TestAllocationSmoke(t *testing.T) {
+
 	apiClient := api.NewAPI()
 
-	// logging in case we can trace potential env issues with go test -v
+	// logging incase we can trace potential env issues with go test -v
 	t.Logf("Smoke target (OPENCOST_URL or default): %s", env.GetDefaultURL())
 
 	testCases := []struct {

--- a/test/integration/api/allocation/allocation_summary_smoke_test.go
+++ b/test/integration/api/allocation/allocation_summary_smoke_test.go
@@ -1,0 +1,47 @@
+package allocation
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+	"github.com/opencost/opencost-integration-tests/pkg/env"
+)
+
+func TestAllocationSummarySmoke(t *testing.T) {
+
+	apiClient := api.NewAPI()
+
+	// logging incase we can trace potential env issues with go test -v
+	t.Logf("Smoke target (OPENCOST_URL or default): %s", env.GetDefaultURL())
+
+	testCases := []struct {
+		name   string
+		window string
+	}{
+		{
+			name:   "ValidQueryTest",
+			window: "1d",
+		},
+	}
+
+	for _, tc := range testCases {
+
+		t.Run(tc.name, func(t *testing.T) {
+
+			ar := api.AllocationRequest{
+				Window: tc.window,
+			}
+			response, err := apiClient.GetAllocationSummary(ar)
+			if err != nil {
+				t.Fatalf("/allocation/summary window=%s request failed: %v", ar.Window, err)
+			}
+
+			if response.Code != 200 {
+				t.Errorf("/allocation/summary window=%s returned non-200 code: %d", ar.Window, response.Code)
+			}
+
+			t.Logf("/allocation/summary: code=%d, allocation sets returned: %d",
+				response.Code, len(response.Data.Sets))
+		})
+	}
+}

--- a/test/integration/api/allocation/allocation_summary_smoke_test.go
+++ b/test/integration/api/allocation/allocation_summary_smoke_test.go
@@ -11,7 +11,7 @@ func TestAllocationSummarySmoke(t *testing.T) {
 
 	apiClient := api.NewAPI()
 
-	// logging incase we can trace potential env issues with go test -v
+	// logging in case we can trace potential env issues with go test -v
 	t.Logf("Smoke target (OPENCOST_URL or default): %s", env.GetDefaultURL())
 
 	testCases := []struct {

--- a/test/integration/api/allocation/allocation_summary_smoke_test.go
+++ b/test/integration/api/allocation/allocation_summary_smoke_test.go
@@ -11,7 +11,7 @@ func TestAllocationSummarySmoke(t *testing.T) {
 
 	apiClient := api.NewAPI()
 
-	// logging in case we can trace potential env issues with go test -v
+	// logging incase we can trace potential env issues with go test -v
 	t.Logf("Smoke target (OPENCOST_URL or default): %s", env.GetDefaultURL())
 
 	testCases := []struct {
@@ -19,7 +19,7 @@ func TestAllocationSummarySmoke(t *testing.T) {
 		window string
 	}{
 		{
-			name:   "ValidQueryTest",
+			name:   "SimpleValidQuery_1d",
 			window: "1d",
 		},
 	}

--- a/test/integration/api/allocation/test.bats
+++ b/test/integration/api/allocation/test.bats
@@ -1,11 +1,21 @@
 setup() {
     DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
-    cd $DIR
+    cd "$DIR"
 }
 
 teardown() {
     : # nothing to tear down
 }
+
+@test "allocation: smoke test allocation" {
+    #60sec cap bc SDK http.Get has no timeout, avoids go test's default 10 min 
+    go test -timeout 60s allocation_smoke_test.go
+}
+
+@test "allocation: smoke test allocation summary" {
+    go test -timeout 60s allocation_summary_smoke_test.go
+}
+
 @test "allocation: controller kind consistency" {
     go test allocation_controller_consistency_test.go
 }

--- a/test/integration/api/asset/assets_smoke_test.go
+++ b/test/integration/api/asset/assets_smoke_test.go
@@ -11,7 +11,7 @@ func TestAssetsSmoke(t *testing.T) {
 
 	apiClient := api.NewAPI()
 
-	// logging in case we can trace potential env issues with go test -v
+	// logging incase we can trace potential env issues with go test -v
 	t.Logf("Assets Smoke target (OPENCOST_URL or default): %s", env.GetDefaultURL())
 
 	testCases := []struct {

--- a/test/integration/api/asset/assets_smoke_test.go
+++ b/test/integration/api/asset/assets_smoke_test.go
@@ -11,7 +11,7 @@ func TestAssetsSmoke(t *testing.T) {
 
 	apiClient := api.NewAPI()
 
-	// logging incase we can trace potential env issues with go test -v
+	// logging in case we can trace potential env issues with go test -v
 	t.Logf("Assets Smoke target (OPENCOST_URL or default): %s", env.GetDefaultURL())
 
 	testCases := []struct {

--- a/test/integration/api/asset/assets_smoke_test.go
+++ b/test/integration/api/asset/assets_smoke_test.go
@@ -1,0 +1,50 @@
+package assets
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+	"github.com/opencost/opencost-integration-tests/pkg/env"
+)
+
+func TestAssetsSmoke(t *testing.T) {
+
+	apiClient := api.NewAPI()
+
+	// logging incase we can trace potential env issues with go test -v
+	t.Logf("Assets Smoke target (OPENCOST_URL or default): %s", env.GetDefaultURL())
+
+	testCases := []struct {
+		name   string
+		window string
+	}{
+		{
+			name:   "ValidQueryTest",
+			window: "1d",
+		},
+	}
+
+	for _, tc := range testCases {
+
+		t.Run(tc.name, func(t *testing.T) {
+
+			ar := api.AssetsRequest{
+				Window: tc.window,
+			}
+			response, err := apiClient.GetAssets(ar)
+			if err != nil {
+				t.Fatalf("/assets?window=%s request failed: %v", ar.Window, err)
+			}
+
+			if response.Code != 200 {
+				t.Errorf("/assets?window=%s returned non-200 code: %d", ar.Window, response.Code)
+			}
+
+			if len(response.Data) == 0 {
+				t.Logf("warning: /assets returned 200 but zero assets")
+			}
+
+			t.Logf("/assets: code=%d, assets returned: %d", response.Code, len(response.Data))
+		})
+	}
+}

--- a/test/integration/api/asset/test.bats
+++ b/test/integration/api/asset/test.bats
@@ -1,10 +1,15 @@
 setup() {
     DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
-    cd $DIR
+    cd "$DIR"
 }
 
 teardown() {
     : # nothing to tear down
+}
+
+@test "asset: Smoke Test" {
+    #60sec cap bc SDK http.Get has no timeout, avoids go test's default 10 min 
+    go test -timeout 60s assets_smoke_test.go 
 }
 
 @test "asset: Node Labels" {

--- a/test/integration/api/asset/test.bats
+++ b/test/integration/api/asset/test.bats
@@ -8,7 +8,7 @@ teardown() {
 }
 
 @test "asset: Smoke Test" {
-    #60sec cap bc SDK http.Get has no timeout, avoids go test's default 10 min
+    #60sec cap bc SDK http.Get has no timeout, avoids go test's default 10 min 
     go test -timeout 60s assets_smoke_test.go 
 }
 

--- a/test/integration/api/asset/test.bats
+++ b/test/integration/api/asset/test.bats
@@ -8,7 +8,7 @@ teardown() {
 }
 
 @test "asset: Smoke Test" {
-    #60sec cap bc SDK http.Get has no timeout, avoids go test's default 10 min 
+    #60sec cap bc SDK http.Get has no timeout, avoids go test's default 10 min
     go test -timeout 60s assets_smoke_test.go 
 }
 


### PR DESCRIPTION
## Description
Adds smoke tests for the `/allocation`, `/allocation/summary`, and `/assets` endpoints. 
Each test issues a request with `window=1d` and verifies the endpoint responds with a 200 status code, providing a fast first-line check that the API is alive before the deeper integration tests run.

Cloud cost endpoint smoke coverage was intentionally left out of this PR: implementing it would require adding a cloud cost client to `pkg/api` first, I've left it for a follow up PR to keep this one focused, but happy to include it here if reviewers prefer.

## Changes
- Added `allocation_smoke_test.go` and `allocation_summary_smoke_test.go` under `test/integration/api/allocation/`
- Added `assets_smoke_test.go` under `test/integration/api/asset/`
- Updated `test/integration/api/allocation/test.bats` and `test/integration/api/asset/test.bats` to register the new smoke tests, with a `-timeout 60s` cap on each `go test` invocation (the SDK's HTTP client has no timeout, so this prevents a hung endpoint from stalling until `go test`'s 10-minute default)

## Related Issues

#74

## Testing

Ran the new smoke tests against a local k3d cluster running OpenCost and the demo cluster; all pass via both `go test -run Smoke ./...` and the bats suite.