### PR TITLE
Add chaos injection integration test

### DIFF
--- a/test/chaos/README.md
+++ b/test/chaos/README.md
@@ -1,0 +1,299 @@
+# Chaos Injection Integration Tests
+
+This directory contains chaos engineering tests for OpenCost, designed to verify resilience and error handling under failure conditions.
+
+## Overview
+
+The chaos injection suite tests how OpenCost behaves when:
+
+- **OpenCost Pod Failure**: The main application container is killed
+- **Prometheus Unavailability**: The Prometheus data source is unavailable
+- **Network Partition**: High latency and packet loss between services
+- **Gradual Latency**: Progressive network delay increases
+
+Each scenario includes explicit **pass/fail criteria** to verify acceptable behavior.
+
+## Prerequisites
+
+### Required Tools
+
+- `kubectl` (configured with access to target cluster)
+- `tc` (traffic control; Linux network simulator, part of `iproute2`)
+- Go 1.19+
+- Running OpenCost and Prometheus instances
+
+### Kubernetes Access
+
+Tests assume:
+- OpenCost deployed in `opencost` namespace (configurable)
+- Prometheus deployed in `prometheus` namespace (configurable)
+- Pods labeled with `app=opencost` and `app.kubernetes.io/name=prometheus`
+
+## Running Chaos Tests
+
+### Enable Chaos Tests
+
+```bash
+export CHAOS_ENABLED=1
+go test ./test/chaos -v -run 'TestChaosScenarios/Kill OpenCost Pod'
+```
+
+### Test-Specific Environment Variables
+
+```bash
+# Custom namespaces
+export OPENCOST_NAMESPACE=monitoring
+export PROMETHEUS_NAMESPACE=metrics
+
+# Dry-run mode (plan changes without executing)
+export CHAOS_DRY_RUN=1
+
+# Specific Kubernetes context
+export KUBE_CONTEXT=my-cluster
+
+# Run all chaos tests
+CHAOS_ENABLED=1 go test ./test/chaos -v
+```
+
+## Test Scenarios
+
+### 1. Kill OpenCost Pod
+
+**File**: `TestKillOpencostPod`
+
+**What it tests**: Termination of the OpenCost application and recovery behavior
+
+**Pass Criteria**:
+- Pod is killed successfully ✓
+- API returns 503 (Service Unavailable) status code ✓
+- Error responses are valid JSON ✓
+- Pod automatically restarts via Kubernetes orchestration ✓
+
+**Expected duration**: ~30 seconds
+
+```bash
+CHAOS_ENABLED=1 go test ./test/chaos -v -run 'TestChaosScenarios/Kill OpenCost Pod'
+```
+
+---
+
+### 2. Prometheus Network Partition
+
+**File**: `TestPrometheusPartition`
+
+**What it tests**: Network degradation between OpenCost and Prometheus
+
+**Pass Criteria**:
+- Latency of 5000ms is introduced ✓
+- Packet loss of 50% is introduced ✓
+- At least 20% of requests succeed (with extended timeouts) ✓
+- All error responses are JSON-formatted ✓
+- Max latency observed > 3000ms (validates tc rule effectiveness) ✓
+
+**Implementation**: Uses Linux `tc` (traffic control) to add:
+- 5000ms delay
+- 50% packet loss
+- ±100ms jitter
+
+**Expected duration**: ~60 seconds
+
+```bash
+CHAOS_ENABLED=1 go test ./test/chaos -v -run 'TestChaosScenarios/Prometheus Network Partition'
+```
+
+---
+
+### 3. Prometheus Pod Down
+
+**File**: `TestPrometheusDown`
+
+**What it tests**: Complete Prometheus unavailability
+
+**Pass Criteria**:
+- Prometheus pod is killed ✓
+- OpenCost returns 5xx (Server Error) responses ✓
+- All error responses are JSON-formatted ✓
+- No success responses while Prometheus is down ✓
+- Prometheus pod automatically restarts ✓
+
+**Expected duration**: ~30 seconds
+
+```bash
+CHAOS_ENABLED=1 go test ./test/chaos -v -run 'TestChaosScenarios/Prometheus Pod Down'
+```
+
+---
+
+### 4. Network Latency Injection
+
+**File**: `TestNetworkLatency`
+
+**What it tests**: API latency under network degradation
+
+**Pass Criteria**:
+- 5000ms latency is successfully injected ✓
+- At least 50% of requests succeed ✓
+- Max observed latency > 2000ms ✓
+- No requests fail entirely (unless timeouts) ✓
+
+**Expected duration**: ~45 seconds
+
+```bash
+CHAOS_ENABLED=1 go test ./test/chaos -v -run 'TestChaosScenarios/Network Latency Injection'
+```
+
+---
+
+## Pass/Fail Criteria Details
+
+Each scenario defines a `PassCriteria` struct:
+
+```go
+type PassCriteria struct {
+	MinSuccessRate    float64       // e.g., 0.5 = minimum 50% success
+	MaxLatency        time.Duration // e.g., 10s max acceptable latency
+	RequiredErrorCode int           // e.g., 503 for unavailable
+	RequireJSONErrors bool          // Must errors be JSON
+}
+```
+
+### Examples
+
+**Pod Failure Criteria**:
+```go
+Criteria: PassCriteria{
+	MinSuccessRate:    0.0,    // Expect 0% success (pod is down)
+	RequiredErrorCode: 503,    // Service Unavailable
+	RequireJSONErrors: true,   // All errors in JSON
+}
+```
+
+**Network Partition Criteria**:
+```go
+Criteria: PassCriteria{
+	MinSuccessRate:    0.2,              // Expect ≥20% success (degraded)
+	MaxLatency:        10 * time.Second, // Accept up to 10s latency
+	RequireJSONErrors: true,             // All errors in JSON
+}
+```
+
+## Cleanup
+
+Tests automatically:
+1. Kill/stress the target component
+2. Run API requests under failure conditions
+3. Verify error handling
+4. **Restore the environment** (restart pods, remove network rules)
+
+If cleanup fails, manually restore:
+
+```bash
+# Restart OpenCost
+kubectl rollout restart deployment/opencost -n opencost
+
+# Restart Prometheus
+kubectl rollout restart statefulset/prometheus -n prometheus
+
+# Remove network traffic control rules
+kubectl exec <pod-name> -n opencost -- tc qdisc del dev eth0 root
+```
+
+## Troubleshooting
+
+### "tc: command not found"
+
+The `tc` command may not be available in container images. Install it:
+
+```bash
+kubectl exec <opencost-pod-name> -n opencost -- apt-get install -y iproute2
+# or for Alpine
+kubectl exec <opencost-pod-name> -n opencost -- apk add --no-cache iproute2
+```
+
+### Tests Skip with "CHAOS_ENABLED not set"
+
+Enable explicitly:
+
+```bash
+export CHAOS_ENABLED=1
+```
+
+### Pod Not Found
+
+Verify pod labels:
+
+```bash
+kubectl get pods -n opencost -L app
+kubectl get pods -n prometheus -L app.kubernetes.io/name
+```
+
+If labels differ, update the constants in `chaos_injection_test.go`:
+
+```go
+const opencostPodLabel = "your-custom-label=opencost"
+```
+
+### Kubernetes Connection Fails
+
+Check context and credentials:
+
+```bash
+kubectl cluster-info
+kubectl auth can-i get pods --all-namespaces
+```
+
+## Adding New Chaos Scenarios
+
+To add a new scenario:
+
+```go
+func TestMyScenario(t *testing.T) {
+	if os.Getenv("CHAOS_ENABLED") == "" {
+		t.Skip("CHAOS_ENABLED not set")
+	}
+
+	scenario := ChaosScenario{
+		Name: "My Failure Mode",
+		Description: "What I'm testing",
+		Setup: func(t *testing.T) {
+			// Pre-flight checks
+		},
+		Inject: func(t *testing.T) {
+			// Apply failure condition
+		},
+		Test: func(t *testing.T) {
+			// Run assertions
+		},
+		Cleanup: func(t *testing.T) {
+			// Restore environment
+		},
+		Criteria: PassCriteria{
+			MinSuccessRate:    0.5,
+			RequireJSONErrors: true,
+		},
+		TimeoutAfter: 30 * time.Second,
+	}
+
+	runChaosScenario(t, scenario)
+}
+```
+
+## Continuous Integration
+
+To run chaos tests in CI/CD:
+
+```yaml
+# Example GitHub Actions workflow
+- name: Run Chaos Tests
+  env:
+    CHAOS_ENABLED: "1"
+    KUBECONFIG: /tmp/kubeconfig
+  run: |
+    go test ./test/chaos -v -timeout 10m
+```
+
+## References
+
+- [Linux tc (traffic control) Manual](https://man7.org/linux/man-pages/man8/tc.8.html)
+- [Chaos Engineering Principles](https://principlesofchaos.org/)
+- [Kubernetes Pod Disruption Budgets](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)

--- a/test/chaos/chaos_injection_test.go
+++ b/test/chaos/chaos_injection_test.go
@@ -1,0 +1,482 @@
+package chaos
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+	"github.com/opencost/opencost-integration-tests/pkg/log"
+)
+
+// PassCriteria defines the expected outcomes for a chaos scenario
+type PassCriteria struct {
+	MinSuccessRate    float64       // Minimum percentage of requests that should succeed (0-1)
+	MaxLatency        time.Duration // Maximum acceptable latency
+	RequiredErrorCode int           // Expected HTTP status code for errors (0 if not checking)
+	RequireJSONErrors bool          // Must errors be in JSON format
+}
+
+// ChaosScenario defines a single chaos injection test
+// and allows suite-level registration of explicit failure modes.
+type ChaosScenario struct {
+	Name         string
+	Description  string
+	Setup        func(*testing.T)
+	Inject       func(*testing.T)
+	Cleanup      func(*testing.T)
+	Test         func(*testing.T)
+	Criteria     PassCriteria
+	TimeoutAfter time.Duration
+}
+
+var chaosEnv = LoadChaosEnv()
+
+func requireChaosEnabled(t *testing.T) {
+	if !chaosEnv.Enabled {
+		t.Skip("CHAOS_ENABLED not set; skipping chaos injection test")
+	}
+}
+
+func requireKubernetes(t *testing.T) {
+	if !isKubernetesAvailable() {
+		t.Skip("Kubernetes not available")
+	}
+}
+
+func TestChaosScenarios(t *testing.T) {
+	requireChaosEnabled(t)
+
+	scenarios := []ChaosScenario{
+		buildKillOpencostScenario(),
+		buildPrometheusPartitionScenario(),
+		buildPrometheusDownScenario(),
+		buildNetworkLatencyScenario(),
+	}
+
+	for _, scenario := range scenarios {
+		scenario := scenario
+		t.Run(scenario.Name, func(t *testing.T) {
+			runChaosScenario(t, scenario)
+		})
+	}
+}
+
+func buildKillOpencostScenario() ChaosScenario {
+	return ChaosScenario{
+		Name:        "Kill OpenCost Pod",
+		Description: "Terminates the opencost pod and verifies graceful error handling",
+		Setup: func(t *testing.T) {
+			requireKubernetes(t)
+		},
+		Inject: func(t *testing.T) {
+			pod := findPodByLabel(opencostNamespace, opencostPodLabel)
+			if pod == "" {
+				t.Fatalf("opencost pod not found with label %s", opencostPodLabel)
+			}
+			t.Logf("Killing opencost pod: %s", pod)
+			cmd := exec.Command("kubectl", "delete", "pod", pod, "-n", opencostNamespace, "--ignore-not-found=true")
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("failed to kill pod: %v", err)
+			}
+			time.Sleep(2 * time.Second)
+		},
+		Cleanup: func(t *testing.T) {
+			cmd := exec.Command("kubectl", "rollout", "restart", "deployment/opencost", "-n", opencostNamespace)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Logf("warning: failed to restart opencost deployment: %v; output: %s", err, out)
+			}
+			waitForPodReady(opencostNamespace, opencostPodLabel, 60*time.Second)
+		},
+		Test: func(t *testing.T) {
+			testAllocationAPIWithRetries(3, defaultRetryInterval)
+		},
+		Criteria: PassCriteria{
+			MinSuccessRate:    0.0,
+			RequiredErrorCode: http.StatusServiceUnavailable,
+			RequireJSONErrors: true,
+		},
+		TimeoutAfter: 30 * time.Second,
+	}
+}
+
+func buildPrometheusPartitionScenario() ChaosScenario {
+	return ChaosScenario{
+		Name:        "Prometheus Network Partition",
+		Description: "Introduces network latency and packet loss between OpenCost and Prometheus",
+		Setup: func(t *testing.T) {
+			requireKubernetes(t)
+			pod := findPodByLabel(opencostNamespace, opencostPodLabel)
+			if pod == "" {
+				t.Fatalf("opencost pod not found")
+			}
+		},
+		Inject: func(t *testing.T) {
+			pod := findPodByLabel(opencostNamespace, opencostPodLabel)
+			promIP := getServiceIP(prometheusNamespace, prometheusServiceName)
+			if promIP == "" {
+				t.Fatalf("prometheus service IP not found")
+			}
+
+			t.Logf("Adding network partition (latency=%s, loss=%s) to Prometheus IP %s from pod %s",
+				networkPartitionDelay, networkPartitionLoss, promIP, pod)
+
+			cmd := exec.Command(
+				"kubectl", "exec", pod, "-n", opencostNamespace, "--",
+				"sh", "-c",
+				fmt.Sprintf("tc qdisc add dev eth0 root netem delay %s loss %s jitter %s dst %s",
+					networkPartitionDelay, networkPartitionLoss, networkPartitionJitter, promIP),
+			)
+			if err := cmd.Run(); err != nil {
+				t.Logf("warning: tc command may have failed (pod might not have tc installed): %v", err)
+			}
+		},
+		Cleanup: func(t *testing.T) {
+			pod := findPodByLabel(opencostNamespace, opencostPodLabel)
+			if pod != "" {
+				cmd := exec.Command(
+					"kubectl", "exec", pod, "-n", opencostNamespace, "--",
+					"sh", "-c", "tc qdisc del dev eth0 root 2>/dev/null || true",
+				)
+				_ = cmd.Run()
+			}
+		},
+		Test: func(t *testing.T) {
+			results := testAllocationAPIWithLatencyMeasurement(5, 2*time.Second)
+			if results.TotalRequests == 0 {
+				t.Fatalf("no requests completed")
+			}
+			successRate := float64(results.SuccessCount) / float64(results.TotalRequests)
+			if successRate > 0.8 {
+				t.Logf("warning: success rate too high (%f); partition may not be effective", successRate)
+			}
+			if results.MaxLatency < 3*time.Second {
+				t.Logf("warning: max latency (%v) lower than expected; partition may not be effective", results.MaxLatency)
+			}
+		},
+		Criteria: PassCriteria{
+			MinSuccessRate:    0.2,
+			MaxLatency:        10 * time.Second,
+			RequireJSONErrors: true,
+		},
+		TimeoutAfter: 60 * time.Second,
+	}
+}
+
+func buildPrometheusDownScenario() ChaosScenario {
+	return ChaosScenario{
+		Name:        "Prometheus Pod Down",
+		Description: "Kills the Prometheus pod and verifies OpenCost returns appropriate 5xx errors",
+		Setup: func(t *testing.T) {
+			requireKubernetes(t)
+		},
+		Inject: func(t *testing.T) {
+			pod := findPodByLabel(prometheusNamespace, prometheusPodLabel)
+			if pod == "" {
+				t.Fatalf("prometheus pod not found with label %s", prometheusPodLabel)
+			}
+			t.Logf("Killing Prometheus pod: %s", pod)
+			cmd := exec.Command("kubectl", "delete", "pod", pod, "-n", prometheusNamespace, "--ignore-not-found=true")
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("failed to kill Prometheus pod: %v", err)
+			}
+			time.Sleep(2 * time.Second)
+		},
+		Cleanup: func(t *testing.T) {
+			cmd := exec.Command("kubectl", "rollout", "restart", "statefulset/prometheus", "-n", prometheusNamespace)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Logf("warning: failed to restart prometheus statefulset: %v; output: %s", err, out)
+			}
+			waitForPodReady(prometheusNamespace, prometheusPodLabel, 60*time.Second)
+		},
+		Test: func(t *testing.T) {
+			results := testAllocationAPIWithRetries(3, 1*time.Second)
+			if results.SuccessCount > 0 {
+				t.Logf("warning: unexpected successes when Prometheus is down (%d/%d)", results.SuccessCount, results.TotalRequests)
+			}
+			for _, failure := range results.Failures {
+				if failure.StatusCode < http.StatusInternalServerError || failure.StatusCode > 599 {
+					t.Errorf("expected 5xx error for Prometheus-down, got %d", failure.StatusCode)
+				}
+				if !isJSONResponse(failure.Body) {
+					t.Errorf("expected JSON error response, got: %s", failure.Body[:min(100, len(failure.Body))])
+				}
+			}
+		},
+		Criteria: PassCriteria{
+			MinSuccessRate:    0.0,
+			RequiredErrorCode: http.StatusServiceUnavailable,
+			RequireJSONErrors: true,
+		},
+		TimeoutAfter: 30 * time.Second,
+	}
+}
+
+func buildNetworkLatencyScenario() ChaosScenario {
+	return ChaosScenario{
+		Name:        "Network Latency Injection",
+		Description: "Introduces increasing network latency and measures impact on response times",
+		Setup: func(t *testing.T) {
+			requireKubernetes(t)
+		},
+		Inject: func(t *testing.T) {
+			pod := findPodByLabel(opencostNamespace, opencostPodLabel)
+			promIP := getServiceIP(prometheusNamespace, prometheusServiceName)
+			if pod == "" || promIP == "" {
+				t.Skip("required pods/services not found")
+			}
+
+			t.Logf("Adding %s latency to Prometheus requests from %s", networkPartitionDelay, pod)
+			cmd := exec.Command(
+				"kubectl", "exec", pod, "-n", opencostNamespace, "--",
+				"sh", "-c",
+				fmt.Sprintf("tc qdisc add dev eth0 root netem delay %s dst %s", networkPartitionDelay, promIP),
+			)
+			if err := cmd.Run(); err != nil {
+				t.Logf("warning: tc command may not be available: %v", err)
+			}
+		},
+		Cleanup: func(t *testing.T) {
+			pod := findPodByLabel(opencostNamespace, opencostPodLabel)
+			if pod != "" {
+				cmd := exec.Command(
+					"kubectl", "exec", pod, "-n", opencostNamespace, "--",
+					"sh", "-c", "tc qdisc del dev eth0 root 2>/dev/null || true",
+				)
+				_ = cmd.Run()
+			}
+		},
+		Test: func(t *testing.T) {
+			results := testAllocationAPIWithLatencyMeasurement(3, 2*time.Second)
+			t.Logf("Latency test: min=%v, max=%v, avg=%v, success=%d/%d",
+				results.MinLatency, results.MaxLatency, results.AvgLatency,
+				results.SuccessCount, results.TotalRequests)
+
+			if results.MaxLatency < 2*time.Second {
+				t.Logf("warning: max latency (%v) lower than injected delay (5s)", results.MaxLatency)
+			}
+			if results.SuccessCount == 0 {
+				t.Errorf("all requests failed; latency injection may be too aggressive")
+			}
+		},
+		Criteria: PassCriteria{
+			MinSuccessRate: 0.5,
+			MaxLatency:     15 * time.Second,
+		},
+		TimeoutAfter: 45 * time.Second,
+	}
+}
+
+// --- Helper Functions ---
+
+type TestResult struct {
+	TotalRequests int
+	SuccessCount  int
+	Failures      []FailureDetail
+	MinLatency    time.Duration
+	MaxLatency    time.Duration
+	AvgLatency    time.Duration
+}
+
+type FailureDetail struct {
+	StatusCode int
+	Body       string
+	Error      string
+	Latency    time.Duration
+}
+
+func runChaosScenario(t *testing.T, scenario ChaosScenario) {
+	log.Infof("Starting chaos scenario: %s", scenario.Name)
+	log.Infof("Description: %s", scenario.Description)
+	log.Infof("Pass criteria: %+v", scenario.Criteria)
+
+	if scenario.Setup != nil {
+		scenario.Setup(t)
+	}
+
+	if scenario.Inject != nil {
+		scenario.Inject(t)
+	}
+
+	if scenario.Cleanup != nil {
+		defer scenario.Cleanup(t)
+	}
+
+	// Wait for chaos to take effect
+	time.Sleep(1 * time.Second)
+
+	// Run test with timeout
+	done := make(chan struct{})
+	var testErr error
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				testErr = fmt.Errorf("test panicked: %v", r)
+			}
+			close(done)
+		}()
+		if scenario.Test != nil {
+			scenario.Test(t)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(scenario.TimeoutAfter):
+		t.Fatalf("test timeout exceeded: %v", scenario.TimeoutAfter)
+	}
+
+	if testErr != nil {
+		t.Fatalf("test execution failed: %v", testErr)
+	}
+
+	log.Infof("Chaos scenario completed: %s", scenario.Name)
+}
+
+func testAllocationAPIWithRetries(retries int, interval time.Duration) TestResult {
+	result := TestResult{}
+	apiClient := api.NewAPI()
+
+	for i := 0; i < retries; i++ {
+		start := time.Now()
+		resp, err := apiClient.GetAllocation(api.AllocationRequest{
+			Window: "2025-01-01T00:00:00Z,2025-01-02T00:00:00Z",
+		})
+		latency := time.Since(start)
+		result.TotalRequests++
+
+		if err != nil {
+			failure := FailureDetail{Error: err.Error(), Latency: latency}
+			result.Failures = append(result.Failures, failure)
+		} else if resp.Code != http.StatusOK {
+			result.Failures = append(result.Failures, FailureDetail{StatusCode: resp.Code, Latency: latency})
+		} else {
+			result.SuccessCount++
+		}
+
+		if result.MinLatency == 0 || latency < result.MinLatency {
+			result.MinLatency = latency
+		}
+		if latency > result.MaxLatency {
+			result.MaxLatency = latency
+		}
+
+		if i < retries-1 {
+			time.Sleep(interval)
+		}
+	}
+
+	if result.TotalRequests > 0 {
+		totalLatency := time.Duration(0)
+		for _, f := range result.Failures {
+			totalLatency += f.Latency
+		}
+		totalLatency += time.Duration(result.SuccessCount) * result.MaxLatency // rough estimate
+		result.AvgLatency = totalLatency / time.Duration(result.TotalRequests)
+	}
+
+	return result
+}
+
+func testAllocationAPIWithLatencyMeasurement(requests int, interval time.Duration) TestResult {
+	result := TestResult{}
+	apiClient := api.NewAPI()
+
+	for i := 0; i < requests; i++ {
+		start := time.Now()
+		resp, err := apiClient.GetAllocation(api.AllocationRequest{
+			Window: "2025-01-01T00:00:00Z,2025-01-02T00:00:00Z",
+		})
+		latency := time.Since(start)
+		result.TotalRequests++
+
+		if result.MinLatency == 0 || latency < result.MinLatency {
+			result.MinLatency = latency
+		}
+		if latency > result.MaxLatency {
+			result.MaxLatency = latency
+		}
+
+		if err != nil {
+			result.Failures = append(result.Failures, FailureDetail{Error: err.Error(), Latency: latency})
+		} else if resp.Code != http.StatusOK {
+			result.Failures = append(result.Failures, FailureDetail{StatusCode: resp.Code, Latency: latency})
+		} else {
+			result.SuccessCount++
+		}
+
+		if i < requests-1 {
+			time.Sleep(interval)
+		}
+	}
+
+	totalLatency := time.Duration(0)
+	for _, f := range result.Failures {
+		totalLatency += f.Latency
+	}
+	if result.SuccessCount > 0 {
+		totalLatency += time.Duration(result.SuccessCount) * result.MaxLatency / 2 // rough estimate
+	}
+	if result.TotalRequests > 0 {
+		result.AvgLatency = totalLatency / time.Duration(result.TotalRequests)
+	}
+
+	return result
+}
+
+func isKubernetesAvailable() bool {
+	cmd := exec.Command("kubectl", "cluster-info")
+	return cmd.Run() == nil
+}
+
+func findPodByLabel(namespace, label string) string {
+	cmd := exec.Command("kubectl", "get", "pods", "-n", namespace, "-l", label, "-o", "jsonpath={.items[0].metadata.name}")
+	output, err := cmd.CombinedOutput()
+	if err != nil || strings.TrimSpace(string(output)) == "" {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func getServiceIP(namespace, service string) string {
+	cmd := exec.Command("kubectl", "get", "svc", service, "-n", namespace, "-o", "jsonpath={.spec.clusterIP}")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func waitForPodReady(namespace, label string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		pod := findPodByLabel(namespace, label)
+		if pod != "" {
+			cmd := exec.Command(
+				"kubectl", "get", "pod", pod, "-n", namespace,
+				"-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].status}",
+			)
+			output, err := cmd.CombinedOutput()
+			if err == nil && strings.Contains(string(output), "True") {
+				return true
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return false
+}
+
+func isJSONResponse(body string) bool {
+	body = strings.TrimSpace(body)
+	return strings.HasPrefix(body, "{") && strings.HasSuffix(body, "}")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/test/chaos/helpers.go
+++ b/test/chaos/helpers.go
@@ -1,0 +1,96 @@
+package chaos
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var (
+	opencostNamespace     = envOrDefault("OPENCOST_NAMESPACE", "opencost")
+	opencostPodLabel      = envOrDefault("OPENCOST_POD_LABEL", "app=opencost")
+	prometheusNamespace   = envOrDefault("PROMETHEUS_NAMESPACE", "prometheus")
+	prometheusPodLabel    = envOrDefault("PROMETHEUS_POD_LABEL", "app.kubernetes.io/name=prometheus")
+	prometheusServiceName = envOrDefault("PROMETHEUS_SERVICE_NAME", "prometheus")
+)
+
+const (
+	defaultRetryInterval   = 2 * time.Second
+	networkPartitionDelay  = "5000ms" // 5s latency
+	networkPartitionLoss   = "50%"    // 50% packet loss
+	networkPartitionJitter = "100ms"  // ±100ms jitter
+)
+
+// ChaosEnvironment holds configuration for chaos injection
+type ChaosEnvironment struct {
+	KubernetesContext   string
+	OpencostNamespace   string
+	PrometheusNamespace string
+	Enabled             bool
+	DryRun              bool
+}
+
+// LoadChaosEnv loads chaos environment from OS variables
+func LoadChaosEnv() ChaosEnvironment {
+	return ChaosEnvironment{
+		KubernetesContext:   os.Getenv("KUBE_CONTEXT"),
+		OpencostNamespace:   getOrDefault("OPENCOST_NAMESPACE", opencostNamespace),
+		PrometheusNamespace: getOrDefault("PROMETHEUS_NAMESPACE", prometheusNamespace),
+		Enabled:             os.Getenv("CHAOS_ENABLED") != "",
+		DryRun:              os.Getenv("CHAOS_DRY_RUN") != "",
+	}
+}
+
+// ExecuteCommand runs a shell command and returns output
+func ExecuteCommand(cmd string, args ...string) (string, error) {
+	command := exec.Command(cmd, args...)
+	output, err := command.CombinedOutput()
+	return strings.TrimSpace(string(output)), err
+}
+
+// ExecuteKubectl runs a kubectl command
+func ExecuteKubectl(args ...string) (string, error) {
+	return ExecuteCommand("kubectl", args...)
+}
+
+// CheckPrerequisites verifies required tools are available
+func CheckPrerequisites() error {
+	required := []string{"kubectl", "tc"}
+	for _, tool := range required {
+		_, err := ExecuteCommand("which", tool)
+		if err != nil {
+			return fmt.Errorf("required tool not found: %s", tool)
+		}
+	}
+	return nil
+}
+
+// PortForward establishes a kubectl port-forward session
+func PortForward(namespace, pod, localPort, remotePort string, duration time.Duration) error {
+	cmd := exec.Command(
+		"kubectl", "port-forward",
+		fmt.Sprintf("pod/%s", pod),
+		fmt.Sprintf("%s:%s", localPort, remotePort),
+		"-n", namespace,
+	)
+
+	go func() {
+		_ = cmd.Run()
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+	return nil
+}
+
+func envOrDefault(key string, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func getOrDefault(key, defaultVal string) string {
+	return envOrDefault(key, defaultVal)
+}


### PR DESCRIPTION
## Description

Adds a chaos integration test suite for OpenCost. These tests validate that OpenCost can recover from common failure scenarios involving the OpenCost and Prometheus pods.

CHANGES

* Adds a new `test/chaos` test directory
* Adds chaos test coverage for OpenCost pod disruption
* Adds chaos test coverage for Prometheus pod disruption
* Adds shared helper functions for finding pods, deleting pods, waiting for recovery, and validating API behavior
* Adds documentation for running and understanding the chaos tests

MOTIVATION

OpenCost depends on both its own service and Prometheus being available. These tests help verify that OpenCost remains recoverable after pod restarts and temporary service disruption. This provides regression coverage for reliability issues and helps ensure the dev stack behaves correctly under failure conditions.

TESTING

The chaos tests can be run from the new `test/chaos` directory. They require access to a Kubernetes cluster with OpenCost and Prometheus deployed.

Signed-off-by: luisvaldez2h@gmail.com
