### PR TITLE
Added empty window tests for Assets and Allocations api

### DIFF
--- a/test/integration/api/allocation/empty_window_test.go
+++ b/test/integration/api/allocation/empty_window_test.go
@@ -1,0 +1,94 @@
+package allocation
+
+import (
+    "testing"
+
+    "github.com/opencost/opencost-integration-tests/pkg/api"
+)
+
+// TestAllocationEmptyWindow validates that allocation API returns a clean, well-formed
+// empty response for valid but data-less windows.
+//
+// Expected response shape for empty windows:
+// - HTTP Code: 200 (success)
+// - Data: empty slice [] or list of empty allocations
+// - No panic or 5xx errors
+func TestAllocationEmptyWindow(t *testing.T) {
+    apiObj := api.NewAPI()
+
+    testCases := []struct {
+        name      string
+        window    string
+        aggregate string
+        describe  string
+    }{
+        {
+            name:      "FarPastWindow",
+            window:    "1970-01-01T00:00:00Z,1970-01-02T00:00:00Z",
+			aggregate: "namespace",
+        },
+        {
+            name:      "FutureWindow",
+            window:    "2099-01-01T00:00:00Z,2099-01-02T00:00:00Z",
+            aggregate: "namespace",
+        },
+        {
+            name:      "BeyondRetentionWindow",
+            window:    "2000-01-01T00:00:00Z,2000-01-02T00:00:00Z",
+            aggregate: "cluster",
+        },
+        {
+            name:      "TestPodEmptyWindow",
+            window:    "1970-01-01T00:00:00Z,1970-01-02T00:00:00Z",
+            aggregate: "pod",
+        },
+        {
+            name:      "TestContainerEmptyWindow",
+            window:    "1970-01-01T00:00:00Z,1970-01-02T00:00:00Z",
+            aggregate: "container",
+        },
+    }
+
+    for _, tc := range testCases {
+        t.Run(tc.name, func(t *testing.T) {
+            t.Logf("Testing: %s - %s", tc.name, tc.window)
+
+            response, err := apiObj.GetAllocation(api.AllocationRequest{
+                Window:    tc.window,
+                Aggregate: tc.aggregate,
+            })
+
+            // Validate no errors occurred
+            if err != nil {
+                t.Fatalf("Unexpected error calling allocation API: %v", err)
+            }
+
+            // Validate HTTP 200
+            if response.Code != 200 {
+                t.Fatalf("Expected HTTP 200, got %d", response.Code)
+            }
+
+            // Validate response structure is well-formed
+            if response.Data == nil {
+                t.Fatalf("Expected non-nil data slice, got nil")
+            }
+
+            // Empty window should have empty data or a single empty map
+            // The exact format depends on the step parameter, but we should
+            // have at least one "window" entry even if no allocations
+            if len(response.Data) == 0 {
+                t.Logf("Data is empty slice (expected for empty window): %v", response.Data)
+            } else {
+                // If data has entries, each should be a map
+                for i, dataMap := range response.Data {
+                    if len(dataMap) == 0 {
+                        t.Logf("Data[%d] is empty map (expected for empty window)", i)
+                    } else {
+                        t.Fatalf("expected empty allocation data for empty window, data[%d] contained allocations: %v", i, dataMap)
+                    }
+                }
+            }
+        })
+    }
+}
+

--- a/test/integration/api/allocation/empty_window_test.go
+++ b/test/integration/api/allocation/empty_window_test.go
@@ -20,7 +20,6 @@ func TestAllocationEmptyWindow(t *testing.T) {
         name      string
         window    string
         aggregate string
-        describe  string
     }{
         {
             name:      "FarPastWindow",

--- a/test/integration/api/allocation/test.bats
+++ b/test/integration/api/allocation/test.bats
@@ -45,3 +45,7 @@ teardown() {
 @test "validate_api: validate if all of idle costs are spread" {
     go test share_idle_shares_test.go
 }
+
+@test "validate_api: validate if api handles empty windows correctly" {
+    go test empty_window_test.go
+}

--- a/test/integration/api/asset/empty_window_test.go
+++ b/test/integration/api/asset/empty_window_test.go
@@ -20,37 +20,32 @@ func TestAssetsEmptyWindow(t *testing.T) {
 		name      string
 		window    string
 		assetType string
-		describe  string
 	}{
 		{
 			name:      "FarPastWindow",
 			window:    "1970-01-01T00:00:00Z,1970-01-02T00:00:00Z",
 			assetType: "node",
-			describe:  "Window from 1970, before any cluster existed",
 		},
 		{
 			name:      "FutureWindow",
 			window:    "2099-01-01T00:00:00Z,2099-01-02T00:00:00Z",
 			assetType: "node",
-			describe:  "Window from 2099, in the future",
 		},
 		{
 			name:      "BeyondRetentionWindow",
 			window:    "2000-01-01T00:00:00Z,2000-01-02T00:00:00Z",
 			assetType: "disk",
-			describe:  "Window from 2000, beyond Prometheus retention",
 		},
 		{
 			name:      "EmptyWindowPVC",
 			window:    "1970-01-01T00:00:00Z,1970-01-02T00:00:00Z",
 			assetType: "pvc",
-			describe:  "PVC assets in empty window",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Logf("Testing: %s - %s", tc.describe, tc.window)
+			t.Logf("Testing: %s - %s", tc.name, tc.window)
 
 			response, err := apiObj.GetAssets(api.AssetsRequest{
 				Window: tc.window,

--- a/test/integration/api/asset/empty_window_test.go
+++ b/test/integration/api/asset/empty_window_test.go
@@ -1,0 +1,83 @@
+package assets
+
+import (
+	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+)
+
+// TestAssetsEmptyWindow validates that assets API returns a clean, well-formed
+// empty response for valid but data-less windows.
+//
+// Expected response shape for empty windows:
+// - HTTP Code: 200 (success)
+// - Data: empty map {} (no assets in the window)
+// - No panic or 5xx errors
+func TestAssetsEmptyWindow(t *testing.T) {
+	apiObj := api.NewAPI()
+
+	testCases := []struct {
+		name      string
+		window    string
+		assetType string
+		describe  string
+	}{
+		{
+			name:      "FarPastWindow",
+			window:    "1970-01-01T00:00:00Z,1970-01-02T00:00:00Z",
+			assetType: "node",
+			describe:  "Window from 1970, before any cluster existed",
+		},
+		{
+			name:      "FutureWindow",
+			window:    "2099-01-01T00:00:00Z,2099-01-02T00:00:00Z",
+			assetType: "node",
+			describe:  "Window from 2099, in the future",
+		},
+		{
+			name:      "BeyondRetentionWindow",
+			window:    "2000-01-01T00:00:00Z,2000-01-02T00:00:00Z",
+			assetType: "disk",
+			describe:  "Window from 2000, beyond Prometheus retention",
+		},
+		{
+			name:      "EmptyWindowPVC",
+			window:    "1970-01-01T00:00:00Z,1970-01-02T00:00:00Z",
+			assetType: "pvc",
+			describe:  "PVC assets in empty window",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Testing: %s - %s", tc.describe, tc.window)
+
+			response, err := apiObj.GetAssets(api.AssetsRequest{
+				Window: tc.window,
+				Filter: tc.assetType,
+			})
+
+			// Validate no errors occurred
+			if err != nil {
+				t.Fatalf("Unexpected error calling assets API: %v", err)
+			}
+
+			// Validate HTTP 200
+			if response.Code != 200 {
+				t.Fatalf("Expected HTTP 200, got %d", response.Code)
+			}
+
+			// Validate response structure is well-formed
+			if response.Data == nil {
+				t.Fatalf("Expected non-nil data map, got nil")
+			}
+
+			// Empty window should return empty map
+			if len(response.Data) == 0 {
+				t.Logf("Data is empty map (expected for empty window)")
+			} else {
+				t.Fatalf("Data has %d entries (filter: %s)", len(response.Data), tc.assetType)
+			}
+		})
+	}
+}

--- a/test/integration/api/asset/test.bats
+++ b/test/integration/api/asset/test.bats
@@ -14,3 +14,7 @@ teardown() {
 @test "asset: Spot Node" {
     go test spot_nodes_test.go
 }
+
+@test "asset: Empty Window" {
+    go test empty_window_test.go
+}


### PR DESCRIPTION
DESCRIPTION

Adds two empty windows tests for OpenCost api. These tests validate that the apis can handle windows where data does not exist.

CHANGES

Adds empty_window_test.go under test/integration/api/allocation
Adds to the test.bats file to run the empty window test
Adds empty_window_test.go under test/integration/api/asset
Adds to the test.bats file to run the empty window test

MOTIVATION

OpenCost should be able handle api calls for data that does not exist, and should return 2** responses with empty datasets instead of 5** responses or panics.

TESTING

These tests can be ran from the test.bats files in the allocation and asset folders.

Signed-off-by: [Ethan.Harding@ibm.com]
