### PR TITLE
fix: retry transient Prometheus connection errors in test harness

### DIFF
--- a/pkg/prometheus/autocomplete_ground_truth.go
+++ b/pkg/prometheus/autocomplete_ground_truth.go
@@ -419,7 +419,7 @@ func (c *Client) runningPodSet(window string, endTime int64, filterRunning bool)
 
 func (c *Client) runPromQLQuery(input PrometheusInput) (PrometheusResponse, error) {
 	promURL := c.ConstructPromQLQueryURL(input)
-	promResp, err := c.httpClient.Get(promURL)
+	promResp, err := c.get(promURL)
 	if err != nil {
 		return PrometheusResponse{}, fmt.Errorf("failed to query Prometheus: %w", err)
 	}

--- a/pkg/prometheus/client.go
+++ b/pkg/prometheus/client.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opencost/opencost-integration-tests/pkg/log"
 	"github.com/opencost/opencost-integration-tests/pkg/utils"
 )
 
@@ -428,6 +429,7 @@ func (c *Client) get(promURL string) (*http.Response, error) {
 			break
 		}
 		if attempt < promQueryMaxAttempts {
+			log.Warnf("prometheus query failed (attempt %d/%d), retrying: %v", attempt, promQueryMaxAttempts, err)
 			time.Sleep(promQueryRetryBackoff * time.Duration(attempt))
 		}
 	}

--- a/pkg/prometheus/client.go
+++ b/pkg/prometheus/client.go
@@ -2,13 +2,17 @@ package prometheus
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -402,6 +406,50 @@ func (dp *DataPoint) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+const promQueryMaxAttempts = 4
+
+// promQueryRetryBackoff is the base delay between query retries; it scales with
+// the attempt number. It is a var so tests can shorten it.
+var promQueryRetryBackoff = 500 * time.Millisecond
+
+// get performs an HTTP GET against Prometheus, retrying transient network errors
+// such as "connection reset by peer" that the shared demo Prometheus
+// occasionally returns and that otherwise fail integration runs spuriously.
+// Prometheus queries are idempotent, so retrying a failed GET is safe.
+func (c *Client) get(promURL string) (*http.Response, error) {
+	var lastErr error
+	for attempt := 1; attempt <= promQueryMaxAttempts; attempt++ {
+		resp, err := c.httpClient.Get(promURL)
+		if err == nil {
+			return resp, nil
+		}
+		lastErr = err
+		if !isRetryableError(err) {
+			break
+		}
+		if attempt < promQueryMaxAttempts {
+			time.Sleep(promQueryRetryBackoff * time.Duration(attempt))
+		}
+	}
+	return nil, lastErr
+}
+
+// isRetryableError reports whether err is a transient network error worth
+// retrying (connection reset, broken pipe, timeout, or unexpected EOF).
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, io.EOF) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return strings.Contains(err.Error(), "connection reset by peer")
+}
+
 // GetPodsByController queries Prometheus for pods of a specific controller type
 func (c *Client) GetPodsByController(controllerKind string, window string) (map[string]string, error) {
 	// For ReplicaSets, we need to query for Deployment-owned pods
@@ -411,7 +459,7 @@ func (c *Client) GetPodsByController(controllerKind string, window string) (map[
 	promQuery := fmt.Sprintf("max_over_time(kube_pod_owner{owner_kind=\"%s\"}[%s])", promQueryKind, window)
 	promURL := fmt.Sprintf("%s/api/v1/query?query=%s", c.baseURL, url.QueryEscape(promQuery))
 
-	promResp, err := c.httpClient.Get(promURL)
+	promResp, err := c.get(promURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query Prometheus for %s with window %s: %v", controllerKind, window, err)
 	}
@@ -523,7 +571,7 @@ func (c *Client) RunPromQLQuery(promQLArgs PrometheusInput, t *testing.T) (Prome
 
 	promURL := c.ConstructPromQLQueryURL(promQLArgs)
 	t.Logf("Running PromQL Query: %s", promURL)
-	promResp, err := c.httpClient.Get(promURL)
+	promResp, err := c.get(promURL)
 
 	var promData PrometheusResponse
 

--- a/pkg/prometheus/client.go
+++ b/pkg/prometheus/client.go
@@ -435,18 +435,21 @@ func (c *Client) get(promURL string) (*http.Response, error) {
 }
 
 // isRetryableError reports whether err is a transient network error worth
-// retrying (connection reset, broken pipe, timeout, or unexpected EOF).
+// retrying: connection reset, broken pipe, timeout, or a connection dropped
+// mid-response (io.EOF or io.ErrUnexpectedEOF on a truncated read).
 func isRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) || errors.Is(err, io.EOF) {
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		return true
 	}
+	// Fallback for resets surfaced by wrappers that don't unwrap to ECONNRESET.
 	return strings.Contains(err.Error(), "connection reset by peer")
 }
 

--- a/pkg/prometheus/retry_test.go
+++ b/pkg/prometheus/retry_test.go
@@ -36,6 +36,13 @@ func connReset() error {
 	return &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}
 }
 
+// timeoutError satisfies net.Error and reports itself as a timeout.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return false }
+
 func TestIsRetryableError(t *testing.T) {
 	cases := []struct {
 		name string
@@ -46,6 +53,8 @@ func TestIsRetryableError(t *testing.T) {
 		{"conn reset", connReset(), true},
 		{"broken pipe", &net.OpError{Op: "write", Err: syscall.EPIPE}, true},
 		{"eof", io.EOF, true},
+		{"unexpected eof", io.ErrUnexpectedEOF, true},
+		{"timeout", timeoutError{}, true},
 		{"wrapped conn reset", &url.Error{Op: "Get", URL: "x", Err: connReset()}, true},
 		{"plain error", errors.New("some other failure"), false},
 	}

--- a/pkg/prometheus/retry_test.go
+++ b/pkg/prometheus/retry_test.go
@@ -1,0 +1,108 @@
+package prometheus
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// flakyTransport fails the first failCount requests with failErr, then returns
+// a 200 response. It records how many times it was called.
+type flakyTransport struct {
+	failCount int
+	failErr   error
+	calls     int
+}
+
+func (f *flakyTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	f.calls++
+	if f.calls <= f.failCount {
+		return nil, f.failErr
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func connReset() error {
+	return &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}
+}
+
+func TestIsRetryableError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"conn reset", connReset(), true},
+		{"broken pipe", &net.OpError{Op: "write", Err: syscall.EPIPE}, true},
+		{"eof", io.EOF, true},
+		{"wrapped conn reset", &url.Error{Op: "Get", URL: "x", Err: connReset()}, true},
+		{"plain error", errors.New("some other failure"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableError(tc.err); got != tc.want {
+				t.Fatalf("isRetryableError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetRetriesTransientThenSucceeds(t *testing.T) {
+	restore := promQueryRetryBackoff
+	promQueryRetryBackoff = time.Millisecond
+	defer func() { promQueryRetryBackoff = restore }()
+
+	ft := &flakyTransport{failCount: 2, failErr: connReset()}
+	c := &Client{httpClient: &http.Client{Transport: ft}}
+
+	resp, err := c.get("http://prometheus.invalid/api/v1/query")
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ft.calls != 3 {
+		t.Fatalf("expected 3 attempts (2 failures + 1 success), got %d", ft.calls)
+	}
+}
+
+func TestGetExhaustsRetriesAndReturnsError(t *testing.T) {
+	restore := promQueryRetryBackoff
+	promQueryRetryBackoff = time.Millisecond
+	defer func() { promQueryRetryBackoff = restore }()
+
+	ft := &flakyTransport{failCount: 100, failErr: connReset()}
+	c := &Client{httpClient: &http.Client{Transport: ft}}
+
+	if _, err := c.get("http://prometheus.invalid/api/v1/query"); err == nil {
+		t.Fatal("expected an error after exhausting retries")
+	}
+	if ft.calls != promQueryMaxAttempts {
+		t.Fatalf("expected %d attempts, got %d", promQueryMaxAttempts, ft.calls)
+	}
+}
+
+func TestGetDoesNotRetryNonTransientError(t *testing.T) {
+	ft := &flakyTransport{failCount: 100, failErr: errors.New("malformed response")}
+	c := &Client{httpClient: &http.Client{Transport: ft}}
+
+	if _, err := c.get("http://prometheus.invalid/api/v1/query"); err == nil {
+		t.Fatal("expected an error")
+	}
+	if ft.calls != 1 {
+		t.Fatalf("expected a single attempt for a non-transient error, got %d", ft.calls)
+	}
+}


### PR DESCRIPTION
## Description

The integration tests query the shared demo Prometheus (`demo-prometheus.infra.opencost.io`) over the public internet, and that endpoint occasionally resets the connection mid query. When it does, the whole run fails even though nothing is actually broken. Example from a recent merge queue run:

```
failed to query Prometheus: Get "https://demo-prometheus.infra.opencost.io/api/v1/query?...":
read tcp 10.1.0.227:60368->129.80.1.124:443: read: connection reset by peer
```

That one knocked opencost/opencost#3865 out of the merge queue, and it shows up intermittently on unrelated PRs too.

This wraps the Prometheus GETs in the test client with a small retry on transient network errors (connection reset, broken pipe, timeout, unexpected EOF) using a linear backoff. Prometheus queries here are read only and idempotent, so retrying a failed GET is safe. All three query paths in `pkg/prometheus` now go through one `c.get()` helper, and a non transient error (anything not network related) still fails immediately so we don't mask real problems.

## Related

Motivated by the flaky merge queue failures, e.g. the run that kicked opencost/opencost#3865. No tracking issue, happy to open one if useful.

## User Impact

Test only change. No production code is touched. Runs that previously failed on a one off connection reset should now ride through it.

## Testing

- Added `pkg/prometheus/retry_test.go`: covers the `isRetryableError` classifier and the retry loop (retries a transient error then succeeds, exhausts retries and returns the error, and does not retry a non transient error). It injects a fake `RoundTripper`, so it is deterministic and needs no network.
- `go build ./...`, `go vet ./pkg/prometheus/`, and the new tests pass locally.

I couldn't reproduce the live connection reset against the demo stack from my machine, so the retry behaviour is verified through the unit tests rather than a full integration run.
