### PR TITLE
Added invalid parameter tests

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -53,18 +53,6 @@ func decodeJSONResponse(url string, httpResp *http.Response, response interface{
 
 	bodyStr := strings.TrimSpace(string(body))
 
-	// Handle Http errors (4xx and 5xx)
-	if httpResp.StatusCode >= 400 {
-
-		retryable = isRetryableHTTPResponse(httpResp.StatusCode, bodyStr)
-
-		return retryable, fmt.Errorf(
-			"HTTP %d: %s",
-			httpResp.StatusCode,
-			bodyStr,
-		)
-	}
-
 	if err := json.Unmarshal(body, response); err != nil {
 		retryable = isRetryableHTTPResponse(httpResp.StatusCode, bodyStr)
 		log.Errorf(

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -52,6 +52,19 @@ func decodeJSONResponse(url string, httpResp *http.Response, response interface{
 	}
 
 	bodyStr := strings.TrimSpace(string(body))
+
+	// Handle Http errors (4xx and 5xx)
+	if httpResp.StatusCode >= 400 {
+
+		retryable = isRetryableHTTPResponse(httpResp.StatusCode, bodyStr)
+
+		return retryable, fmt.Errorf(
+			"HTTP %d: %s",
+			httpResp.StatusCode,
+			bodyStr,
+		)
+	}
+
 	if err := json.Unmarshal(body, response); err != nil {
 		retryable = isRetryableHTTPResponse(httpResp.StatusCode, bodyStr)
 		log.Errorf(

--- a/test/integration/api/allocation/invalid_query_parameter_test.go
+++ b/test/integration/api/allocation/invalid_query_parameter_test.go
@@ -65,7 +65,7 @@ func TestAllocationInvalidParameters(t *testing.T) {
 
 	for _, tc := range invalidWindowTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Logf("Testing: %s - %s", tc.name)
+			t.Logf("Testing: %s", tc.name)
 
 			_, err := apiObj.GetAllocation(api.AllocationRequest{
 				Window:      tc.window,

--- a/test/integration/api/allocation/invalid_query_parameter_test.go
+++ b/test/integration/api/allocation/invalid_query_parameter_test.go
@@ -1,0 +1,89 @@
+package allocation
+
+// Validates that allocation api handles invalid parameters correctly.
+// Passing Criteria:
+// Returns a HTTP 400 error instead of a response with no error or an HTTP 500 error.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+)
+
+func TestAllocationInvalidParameters(t *testing.T) {
+	apiObj := api.NewAPI()
+
+	invalidWindowTestCases := []struct {
+		name        string
+		window      string
+		filter      string
+		aggregate   string
+		accumulate  string
+		includeidle string
+	}{
+		{
+			name:      "ReverseWindow",
+			window:    "2026-06-16T00:00:00Z,2026-06-15T00:00:00Z",
+			aggregate: "namespace",
+		},
+		{
+			name:      "InvalidWindowFormat",
+			window:    "invalid-window-format",
+			aggregate: "namespace",
+		},
+		{
+			name:        "InvalidAggregate",
+			window:      "24h",
+			aggregate:   "invalid-aggregate",
+			accumulate:  "true",
+			includeidle: "true",
+		},
+		{
+			name:        "InvalidFilter",
+			window:      "24h",
+			filter:      "invalid-filter",
+			accumulate:  "true",
+			includeidle: "true",
+			aggregate:   "namespace",
+		},
+		{
+			name:        "InvalidAccumulate",
+			window:      "24h",
+			accumulate:  "invalid-accumulate",
+			includeidle: "true",
+			aggregate:   "namespace",
+		},
+		{
+			name:        "InvalidIncludeIdle",
+			window:      "24h",
+			accumulate:  "true",
+			includeidle: "invalid-include-idle",
+			aggregate:   "namespace",
+		},
+	}
+
+	for _, tc := range invalidWindowTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Testing: %s - %s", tc.name)
+
+			_, err := apiObj.GetAllocation(api.AllocationRequest{
+				Window:      tc.window,
+				Filter:      tc.filter,
+				Accumulate:  tc.accumulate,
+				IncludeIdle: tc.includeidle,
+				Aggregate:   tc.aggregate,
+			})
+
+			// Assert that an error was returned since input is invalid.
+			if err == nil {
+				t.Fatalf("Expected an error for invalid input, but got a successful response")
+			}
+
+			// Assert that it is a 400 error.
+			if !strings.Contains(err.Error(), "HTTP 400") {
+				t.Fatalf("expected HTTP 400 error, got %v", err)
+			}
+		})
+	}
+}

--- a/test/integration/api/allocation/invalid_query_parameter_test.go
+++ b/test/integration/api/allocation/invalid_query_parameter_test.go
@@ -14,7 +14,7 @@ import (
 func TestAllocationInvalidParameters(t *testing.T) {
 	apiObj := api.NewAPI()
 
-	invalidWindowTestCases := []struct {
+	invalidParameterTestCases := []struct {
 		name        string
 		window      string
 		filter      string
@@ -63,7 +63,7 @@ func TestAllocationInvalidParameters(t *testing.T) {
 		},
 	}
 
-	for _, tc := range invalidWindowTestCases {
+	for _, tc := range invalidParameterTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Testing: %s", tc.name)
 

--- a/test/integration/api/allocation/test.bats
+++ b/test/integration/api/allocation/test.bats
@@ -6,6 +6,7 @@ setup() {
 teardown() {
     : # nothing to tear down
 }
+
 @test "allocation: controller kind consistency" {
     go test allocation_controller_consistency_test.go
 }
@@ -44,4 +45,8 @@ teardown() {
 
 @test "validate_api: validate if all of idle costs are spread" {
     go test share_idle_shares_test.go
+}
+
+@test "validate_api: validate api can handle invalid parameters" {
+    go test invalid_query_parameter_test.go
 }

--- a/test/integration/api/asset/invalid_query_parameter_test.go
+++ b/test/integration/api/asset/invalid_query_parameter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/opencost/opencost-integration-tests/pkg/api"
 )
 
-func TestAllocationInvalidParameters(t *testing.T) {
+func TestAssetInvalidParameters(t *testing.T) {
 	apiObj := api.NewAPI()
 
 	invalidWindowTestCases := []struct {

--- a/test/integration/api/asset/invalid_query_parameter_test.go
+++ b/test/integration/api/asset/invalid_query_parameter_test.go
@@ -1,0 +1,57 @@
+package assets
+
+// Validates that assets api handles invalid parameters correctly.
+// Passing Criteria:
+// Returns a HTTP 400 error instead of a response with no error or an HTTP 500 error.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/opencost/opencost-integration-tests/pkg/api"
+)
+
+func TestAllocationInvalidParameters(t *testing.T) {
+	apiObj := api.NewAPI()
+
+	invalidWindowTestCases := []struct {
+		name      string
+		window    string
+		assetType string
+	}{
+		{
+			name:      "ReverseWindow",
+			window:    "2026-06-16T00:00:00Z,2026-06-15T00:00:00Z",
+			assetType: "node",
+		},
+		{
+			name:      "InvalidWindowFormat",
+			window:    "invalid-window-format",
+			assetType: "node",
+		},
+		{
+			name:      "InvalidFilter",
+			window:    "24h",
+			assetType: "invalid-filter",
+		},
+	}
+
+	for _, tc := range invalidWindowTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Testing: %s - %s", tc.name)
+
+			_, err := apiObj.GetAssets(api.AssetsRequest{
+				Window: tc.window,
+				Filter: tc.assetType,
+			})
+
+			if err == nil {
+				t.Fatalf("Expected an error for invalid input, but got a successful response")
+			}
+
+			if !strings.Contains(err.Error(), "HTTP 400") {
+				t.Fatalf("expected HTTP 400 error, got %v", err)
+			}
+		})
+	}
+}

--- a/test/integration/api/asset/invalid_query_parameter_test.go
+++ b/test/integration/api/asset/invalid_query_parameter_test.go
@@ -14,7 +14,7 @@ import (
 func TestAssetInvalidParameters(t *testing.T) {
 	apiObj := api.NewAPI()
 
-	invalidWindowTestCases := []struct {
+	invalidParameterTestCases := []struct {
 		name      string
 		window    string
 		assetType string
@@ -36,7 +36,7 @@ func TestAssetInvalidParameters(t *testing.T) {
 		},
 	}
 
-	for _, tc := range invalidWindowTestCases {
+	for _, tc := range invalidParameterTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Testing: %s", tc.name)
 

--- a/test/integration/api/asset/invalid_query_parameter_test.go
+++ b/test/integration/api/asset/invalid_query_parameter_test.go
@@ -38,7 +38,7 @@ func TestAllocationInvalidParameters(t *testing.T) {
 
 	for _, tc := range invalidWindowTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Logf("Testing: %s - %s", tc.name)
+			t.Logf("Testing: %s", tc.name)
 
 			_, err := apiObj.GetAssets(api.AssetsRequest{
 				Window: tc.window,

--- a/test/integration/api/asset/test.bats
+++ b/test/integration/api/asset/test.bats
@@ -7,6 +7,10 @@ teardown() {
     : # nothing to tear down
 }
 
+@test "asset: Invalid Parameters" {
+    go test invalid_query_parameter_test.go
+}
+
 @test "asset: Node Labels" {
     go test node_labels_test.go
 }


### PR DESCRIPTION
DESCRIPTION

Adds invalid parameter tests for the asset and allocation api. This test validates that the apis handle invalid parameters correctly.

CHANGES

Adds a new invalid_query_parameter_test.go in the allocation and asset folder.
Adds to the test.bats file to run the tests.

MOTIVATION

Invalid Parameters should not return 500 errors or panics. Furthermore, they should not return successful responses, since the responses would then have to guess what is meant by the parameters.

TESTING

This test can be run from the new sanity test directory using the included Bats test file.

Signed-off-by: HardingEthan15 <Ethan.Harding@ibm.com>