### PR TITLE
fix: use pull_request instead of pull_request_target for run-tests

### DIFF
--- a/.github/workflows/integration-testing.yaml
+++ b/.github/workflows/integration-testing.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
   merge_group:


### PR DESCRIPTION
One-liner. `run-tests` doesn't use any secrets, just runs go vet + bats against the public demo URLs, so `pull_request_target` was giving it elevated access it doesn't need, and now actions/checkout refuses to even check out fork code under that trigger. Switched to plain `pull_request`, which also happens to fix `set-labels`'s `if` condition (it was checking for `pull_request` while the trigger was `pull_request_target`, so it never actually ran).

Didn't use `allow-unsafe-pr-checkout: true`, that would bring back the exact risk the checkout guard is there to prevent.

Fixes #116
